### PR TITLE
Added effect layering and skip if blank flag

### DIFF
--- a/src/main/kotlin/io/cyborgsquirrel/jobs/init/LightEffectInitJob.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/jobs/init/LightEffectInitJob.kt
@@ -56,9 +56,8 @@ class LightEffectInitJob(
                         val filters = createLightingService.createEffectFilterFromEntity(effectEntity)
                         val activeEffect = ActiveLightEffect(
                             effectUuid = effectEntity.uuid,
-                            // TODO add priority and skipFramesIfBlank to persistence layer
-                            priority = 0,
-                            skipFramesIfBlank = true,
+                            layer = effectEntity.layer,
+                            skipFramesIfBlank = effectSettings.skipFramesIfBlank,
                             status = effectEntity.status,
                             strip = strip,
                             effect = lightEffect,

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effect_settings/entity/LightEffectSettingsEntity.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effect_settings/entity/LightEffectSettingsEntity.kt
@@ -17,6 +17,7 @@ data class LightEffectSettingsEntity(
     var type: String,
     var name: String,
     var isDefault: Boolean = false,
+    var skipFramesIfBlank: Boolean = true,
 
     @param:TypeDef(type = DataType.JSON)
     var settings: Map<String, Any>,
@@ -29,6 +30,7 @@ data class LightEffectSettingsEntity(
         if (type != other.type) return false
         if (name != other.name) return false
         if (isDefault != other.isDefault) return false
+        if (skipFramesIfBlank != other.skipFramesIfBlank) return false
         if (settings != other.settings) return false
         return true
     }
@@ -39,10 +41,11 @@ data class LightEffectSettingsEntity(
         result = 31 * result + type.hashCode()
         result = 31 * result + name.hashCode()
         result = 31 * result + isDefault.hashCode()
+        result = 31 * result + skipFramesIfBlank.hashCode()
         result = 31 * result + settings.hashCode()
         return result
     }
 
     override fun toString(): String =
-        "LightEffectSettingsEntity(id=$id, uuid=$uuid, type=$type, name=$name, isDefault=$isDefault)"
+        "LightEffectSettingsEntity(id=$id, uuid=$uuid, type=$type, name=$name, isDefault=$isDefault, skipFramesIfBlank=$skipFramesIfBlank)"
 }

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/ActiveLightEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/ActiveLightEffect.kt
@@ -6,7 +6,7 @@ import io.cyborgsquirrel.lighting.model.LedStripModel
 
 data class ActiveLightEffect(
     val effectUuid: String,
-    val priority: Int,
+    val layer: Int,
     val skipFramesIfBlank: Boolean,
     val status: LightEffectStatus,
     val effect: LightEffect,

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/entity/LightEffectEntity.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/entity/LightEffectEntity.kt
@@ -40,6 +40,8 @@ data class LightEffectEntity(
 
     var name: String,
 
+    var layer: Int = 0,
+
     @Enumerated(EnumType.STRING)
     var status: LightEffectStatus,
 ) {
@@ -53,6 +55,7 @@ data class LightEffectEntity(
         if (palette?.id != other.palette?.id) return false
         if (effectSettings?.id != other.effectSettings?.id) return false
         if (uuid != other.uuid) return false
+        if (layer != other.layer) return false
         if (status != other.status) return false
 
         return true
@@ -65,11 +68,12 @@ data class LightEffectEntity(
         result = 31 * result + (pool?.id ?: 0).hashCode()
         result = 31 * result + (palette?.id ?: 0).hashCode()
         result = 31 * result + (effectSettings?.id ?: 0).hashCode()
+        result = 31 * result + layer.hashCode()
         result = 31 * result + status.hashCode()
         return result
     }
 
     override fun toString(): String {
-        return "LightEffectEntity(strip=${strip?.id}, pool=${pool?.id}, palette=${palette?.id}, effectSettings=${effectSettings?.id}, id=$id, uuid=$uuid, name=$name, status=$status)"
+        return "LightEffectEntity(strip=${strip?.id}, pool=${pool?.id}, palette=${palette?.id}, effectSettings=${effectSettings?.id}, id=$id, uuid=$uuid, name=$name, layer=$layer, status=$status)"
     }
 }

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/requests/CreateEffectRequest.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/requests/CreateEffectRequest.kt
@@ -11,4 +11,5 @@ data class CreateEffectRequest(
     val settings: Map<String, Any>?,
     val paletteUuid: String?,
     val settingsUuid: String?,
+    val layer: Int? = null,
 )

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/requests/CreateEffectSettingsRequest.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/requests/CreateEffectSettingsRequest.kt
@@ -8,4 +8,5 @@ data class CreateEffectSettingsRequest(
     val name: String,
     val settings: Map<String, Any>,
     val isDefault: Boolean = false,
+    val skipFramesIfBlank: Boolean = true,
 )

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/requests/UpdateEffectRequest.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/requests/UpdateEffectRequest.kt
@@ -9,4 +9,5 @@ data class UpdateEffectRequest(
     val paletteUuid: String?,
     val settingsUuid: String?,
     val name: String?,
+    val layer: Int? = null,
 )

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/requests/UpdateEffectSettingsRequest.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/requests/UpdateEffectSettingsRequest.kt
@@ -7,4 +7,5 @@ data class UpdateEffectSettingsRequest(
     val name: String?,
     val settings: Map<String, Any>?,
     val isDefault: Boolean?,
+    val skipFramesIfBlank: Boolean?,
 )

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/responses/GetEffectResponse.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/responses/GetEffectResponse.kt
@@ -11,4 +11,5 @@ sealed class GetEffectResponse(
     open val settingsUuid: String?,
     open val status: LightEffectStatus,
     open val category: EffectCategory,
+    open val layer: Int,
 )

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/responses/GetEffectSettingsResponse.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/responses/GetEffectSettingsResponse.kt
@@ -9,4 +9,5 @@ data class GetEffectSettingsResponse(
     val name: String,
     val settings: Map<String, Any>,
     val isDefault: Boolean,
+    val skipFramesIfBlank: Boolean,
 )

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/responses/GetPoolEffectResponse.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/responses/GetPoolEffectResponse.kt
@@ -14,6 +14,7 @@ data class GetPoolEffectResponse(
     override val settingsUuid: String?,
     override val status: LightEffectStatus,
     override val category: EffectCategory,
+    override val layer: Int = 0,
 ) : GetEffectResponse(
-    name, type, uuid, paletteUuid, settingsUuid, status, category
+    name, type, uuid, paletteUuid, settingsUuid, status, category, layer
 )

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/responses/GetStripEffectResponse.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/responses/GetStripEffectResponse.kt
@@ -14,6 +14,7 @@ data class GetStripEffectResponse(
     override val settingsUuid: String?,
     override val status: LightEffectStatus,
     override val category: EffectCategory,
+    override val layer: Int = 0,
 ) : GetEffectResponse(
-    name, type, uuid, paletteUuid, settingsUuid, status, category
+    name, type, uuid, paletteUuid, settingsUuid, status, category, layer
 )

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/responses/GetUnassignedEffectResponse.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/responses/GetUnassignedEffectResponse.kt
@@ -16,6 +16,7 @@ data class GetUnassignedEffectResponse(
     override val settingsUuid: String?,
     override val status: LightEffectStatus,
     override val category: EffectCategory,
+    override val layer: Int = 0,
 ) : GetEffectResponse(
-    name, type, uuid, paletteUuid, settingsUuid, status, category
+    name, type, uuid, paletteUuid, settingsUuid, status, category, layer
 )

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/service/EffectApiService.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/service/EffectApiService.kt
@@ -3,6 +3,8 @@ package io.cyborgsquirrel.lighting.effects.service
 import io.cyborgsquirrel.event_source.model.EffectSettingsEvent
 import io.cyborgsquirrel.event_source.model.LightEffectEvent
 import io.cyborgsquirrel.event_source.service.SseEventEmitter
+import io.cyborgsquirrel.led_strips.entity.LedStripEntity
+import io.cyborgsquirrel.led_strips.entity.LedStripPoolEntity
 import io.cyborgsquirrel.led_strips.repository.LedStripPoolRepository
 import io.cyborgsquirrel.led_strips.repository.LedStripRepository
 import io.cyborgsquirrel.lighting.effect_palette.repository.LightEffectPaletteRepository
@@ -88,14 +90,18 @@ class EffectApiService(
             stripUuid != null -> {
                 val stripEntityOptional = stripRepository.findByUuid(stripUuid)
                 if (stripEntityOptional.isPresent) {
+                    val stripEntity = stripEntityOptional.get()
+                    val layer = request.layer ?: nextAvailableLayer(stripEntity = stripEntity, poolEntity = null, excludeUuid = null)
+                    validateLayerAvailable(stripEntity = stripEntity, poolEntity = null, layer = layer, excludeUuid = null)
                     effectRepository.save(
                         LightEffectEntity(
-                            strip = stripEntityOptional.get(),
+                            strip = stripEntity,
                             uuid = UUID.randomUUID().toString(),
                             name = request.name,
                             status = LightEffectStatus.Inactive,
                             effectSettings = settingsEntity,
                             palette = paletteEntity,
+                            layer = layer,
                         )
                     )
                 } else {
@@ -106,14 +112,18 @@ class EffectApiService(
             poolUuid != null -> {
                 val poolEntityOptional = poolRepository.findByUuid(poolUuid)
                 if (poolEntityOptional.isPresent) {
+                    val poolEntity = poolEntityOptional.get()
+                    val layer = request.layer ?: nextAvailableLayer(stripEntity = null, poolEntity = poolEntity, excludeUuid = null)
+                    validateLayerAvailable(stripEntity = null, poolEntity = poolEntity, layer = layer, excludeUuid = null)
                     effectRepository.save(
                         LightEffectEntity(
-                            pool = poolEntityOptional.get(),
+                            pool = poolEntity,
                             uuid = UUID.randomUUID().toString(),
                             name = request.name,
                             status = LightEffectStatus.Inactive,
                             palette = paletteEntity,
                             effectSettings = settingsEntity,
+                            layer = layer,
                         )
                     )
                 } else {
@@ -139,9 +149,8 @@ class EffectApiService(
 
         val activeEffect = ActiveLightEffect(
             effectUuid = effectEntity.uuid,
-            // TODO add priority to persistence layer
-            priority = 0,
-            skipFramesIfBlank = true,
+            layer = effectEntity.layer,
+            skipFramesIfBlank = settingsEntity.skipFramesIfBlank,
             status = effectEntity.status,
             strip = strip,
             effect = lightEffect,
@@ -169,6 +178,7 @@ class EffectApiService(
                     status = it.status,
                     type = settingsEntity.type,
                     category = EffectCategory.forEffect(settingsEntity.type),
+                    layer = it.layer,
                 )
             }
 
@@ -194,6 +204,7 @@ class EffectApiService(
                     status = it.status,
                     type = settingsEntity.type,
                     category = EffectCategory.forEffect(settingsEntity.type),
+                    layer = it.layer,
                 )
             }
 
@@ -318,6 +329,22 @@ class EffectApiService(
                 }
             }
 
+            val targetLayer = updateEffectRequest.layer ?: nextAvailableLayer(
+                stripEntity = effectEntity.strip,
+                poolEntity = effectEntity.pool,
+                excludeUuid = effectEntity.uuid,
+            )
+            if (targetLayer != effectEntity.layer) {
+                effectEntity = effectEntity.copy(layer = targetLayer)
+            }
+
+            validateLayerAvailable(
+                stripEntity = effectEntity.strip,
+                poolEntity = effectEntity.pool,
+                layer = effectEntity.layer,
+                excludeUuid = effectEntity.uuid,
+            )
+
             effectEntity = effectRepository.update(effectEntity)
 
             var effectModel = effectRegistry.getEffectWithUuid(uuid)
@@ -342,11 +369,11 @@ class EffectApiService(
                     // This retains the state of the effect and just swaps the palette.
                     effectModel.effect.updatePalette(palette)
                 } else {
+                    val updatedSettings = effectEntity.effectSettings
                     effectModel = effectModel.copy(
                         effectUuid = effectEntity.uuid,
-                        // TODO add priority to persistence layer
-                        priority = 0,
-                        skipFramesIfBlank = true,
+                        layer = effectEntity.layer,
+                        skipFramesIfBlank = updatedSettings?.skipFramesIfBlank ?: effectModel.skipFramesIfBlank,
                         status = effectEntity.status,
                         strip = strip,
                         effect = lightEffect,
@@ -405,6 +432,7 @@ class EffectApiService(
                 status = lightEffectEntity.status,
                 type = settingsEntity.type,
                 category = EffectCategory.forEffect(settingsEntity.type),
+                layer = lightEffectEntity.layer,
             )
         } else if (lightEffectEntity.pool != null) {
             GetPoolEffectResponse(
@@ -416,6 +444,7 @@ class EffectApiService(
                 status = lightEffectEntity.status,
                 type = settingsEntity.type,
                 category = EffectCategory.forEffect(settingsEntity.type),
+                layer = lightEffectEntity.layer,
             )
         } else {
             GetUnassignedEffectResponse(
@@ -426,6 +455,7 @@ class EffectApiService(
                 status = lightEffectEntity.status,
                 type = settingsEntity.type,
                 category = EffectCategory.forEffect(settingsEntity.type),
+                layer = lightEffectEntity.layer,
             )
         }
     }
@@ -508,6 +538,7 @@ class EffectApiService(
                 name = request.name,
                 settings = request.settings,
                 isDefault = request.isDefault,
+                skipFramesIfBlank = request.skipFramesIfBlank,
             )
         )
         sseEventEmitter.emit(EffectSettingsEvent.EffectSettingsCreated(entity.uuid))
@@ -526,6 +557,7 @@ class EffectApiService(
             name = request.name ?: entity.name,
             settings = request.settings ?: entity.settings,
             isDefault = request.isDefault ?: entity.isDefault,
+            skipFramesIfBlank = request.skipFramesIfBlank ?: entity.skipFramesIfBlank,
         )
         settingsRepository.update(entity)
         sseEventEmitter.emit(EffectSettingsEvent.EffectSettingsUpdated(uuid))
@@ -545,6 +577,40 @@ class EffectApiService(
         }
     }
 
+    private fun nextAvailableLayer(
+        stripEntity: LedStripEntity?,
+        poolEntity: LedStripPoolEntity?,
+        excludeUuid: String?,
+    ): Int {
+        val existing = when {
+            stripEntity != null -> effectRepository.findByStrip(stripEntity)
+            poolEntity != null -> effectRepository.findByPool(poolEntity)
+            else -> return 0
+        }
+        val maxLayer = existing.filter { it.uuid != excludeUuid }.maxOfOrNull { it.layer }
+        return maxLayer?.plus(1) ?: 0
+    }
+
+    private fun validateLayerAvailable(
+        stripEntity: LedStripEntity?,
+        poolEntity: LedStripPoolEntity?,
+        layer: Int,
+        excludeUuid: String?,
+    ) {
+        val conflicts = when {
+            stripEntity != null -> effectRepository.findByStrip(stripEntity)
+            poolEntity != null -> effectRepository.findByPool(poolEntity)
+            else -> return
+        }
+        val conflict = conflicts.firstOrNull { it.layer == layer && it.uuid != excludeUuid }
+        if (conflict != null) {
+            val ownerDesc = stripEntity?.let { "strip ${it.uuid}" } ?: "pool ${poolEntity?.uuid}"
+            throw ClientRequestException(
+                "Layer $layer is already used by effect ${conflict.uuid} on $ownerDesc. Layers must be unique per strip/pool."
+            )
+        }
+    }
+
     private fun getSettings(entity: LightEffectEntity): LightEffectSettingsEntity {
         // Missing settings shouldn't be possible due to SQL constraints, if this happens something went very wrong.
         return entity.effectSettings
@@ -557,6 +623,7 @@ class EffectApiService(
         name = name,
         settings = settings,
         isDefault = isDefault,
+        skipFramesIfBlank = skipFramesIfBlank,
     )
 
     fun getAllSchemas(): List<EffectSettingsSchema> = LightEffectType.entries.map { effectType ->

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/rendering/LightEffectRendererImpl.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/rendering/LightEffectRendererImpl.kt
@@ -97,7 +97,7 @@ class LightEffectRendererImpl(
 
     private fun renderFrame(strip: LedStripModel): RenderedFrameModel? {
         val activeEffects =
-            effectRepository.getAllEffectsForStrip(strip.uuid).filter { it.status.isInUse() }.sortedBy { it.priority }
+            effectRepository.getAllEffectsForStrip(strip.uuid).filter { it.status.isInUse() }.sortedBy { it.layer }
         return if (activeEffects.isEmpty()) {
             null
         } else {
@@ -110,8 +110,8 @@ class LightEffectRendererImpl(
         activeEffects: List<ActiveLightEffect>
     ): RenderedFrameModel {
         val allEffectsRgbData = mutableListOf<List<RgbColor>>()
-        val activeEffectsByPriority = activeEffects.sortedBy { it.priority }
-        for (activeEffect in activeEffectsByPriority) {
+        val activeEffectsByLayer = activeEffects.sortedBy { it.layer }
+        for (activeEffect in activeEffectsByLayer) {
             logger.debug("Rendering effect {}", activeEffect)
             var rgbData = if (activeEffect.status == LightEffectStatus.Playing) {
                 activeEffect.effect.getNextStep()

--- a/src/main/resources/db/migration/h2/V3__add_layer_and_skip_blank.sql
+++ b/src/main/resources/db/migration/h2/V3__add_layer_and_skip_blank.sql
@@ -1,0 +1,4 @@
+ALTER TABLE light_effect_settings ADD COLUMN skip_frames_if_blank BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE light_effects ADD COLUMN layer INT NOT NULL DEFAULT 0;
+ALTER TABLE light_effects ADD CONSTRAINT light_effects_strip_layer_uq UNIQUE (strip_id, layer);
+ALTER TABLE light_effects ADD CONSTRAINT light_effects_pool_layer_uq UNIQUE (pool_id, layer);

--- a/src/main/resources/db/migration/postgres/V3__add_layer_and_skip_blank.sql
+++ b/src/main/resources/db/migration/postgres/V3__add_layer_and_skip_blank.sql
@@ -1,0 +1,4 @@
+ALTER TABLE light_effect_settings ADD COLUMN skip_frames_if_blank BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE light_effects ADD COLUMN layer INT NOT NULL DEFAULT 0;
+ALTER TABLE light_effects ADD CONSTRAINT light_effects_strip_layer_uq UNIQUE (strip_id, layer);
+ALTER TABLE light_effects ADD CONSTRAINT light_effects_pool_layer_uq UNIQUE (pool_id, layer);

--- a/src/test/kotlin/io/cyborgsquirrel/home/controller/HomeControllerTest.kt
+++ b/src/test/kotlin/io/cyborgsquirrel/home/controller/HomeControllerTest.kt
@@ -103,6 +103,7 @@ class HomeControllerTest(
                 paletteUuid = null,
                 settingsUuid = playingEffect.effectSettings?.uuid,
                 category = EffectCategory.forEffect(playingEffect.effectSettings!!.type),
+                layer = playingEffect.layer,
             ),
         )
     }

--- a/src/test/kotlin/io/cyborgsquirrel/home/services/HomeApiServiceTest.kt
+++ b/src/test/kotlin/io/cyborgsquirrel/home/services/HomeApiServiceTest.kt
@@ -126,6 +126,7 @@ class HomeApiServiceTest(
                 paletteUuid = null,
                 settingsUuid = playingEffect.effectSettings?.uuid,
                 category = EffectCategory.forEffect(playingEffect.effectSettings!!.type),
+                layer = playingEffect.layer,
             ),
             GetStripEffectResponse(
                 uuid = pausedEffect.uuid,
@@ -136,6 +137,7 @@ class HomeApiServiceTest(
                 paletteUuid = null,
                 settingsUuid = pausedEffect.effectSettings?.uuid,
                 category = EffectCategory.forEffect(pausedEffect.effectSettings!!.type),
+                layer = pausedEffect.layer,
             ),
         )
     }

--- a/src/test/kotlin/io/cyborgsquirrel/jobs/streaming/nightdriver/NightDriverSocketJobTest.kt
+++ b/src/test/kotlin/io/cyborgsquirrel/jobs/streaming/nightdriver/NightDriverSocketJobTest.kt
@@ -16,7 +16,6 @@ import io.cyborgsquirrel.lighting.model.SingleLedStripModel
 import io.cyborgsquirrel.lighting.rendering.LightEffectRenderer
 import io.cyborgsquirrel.util.time.TimeHelper
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.*
 import kotlinx.coroutines.*
@@ -69,7 +68,7 @@ class NightDriverSocketJobTest : StringSpec({
     )
     val activeEffect = ActiveLightEffect(
         effectUuid = "nd-effect-uuid",
-        priority = 0,
+        layer = 0,
         skipFramesIfBlank = false,
         status = LightEffectStatus.Playing,
         effect = mockk<LightEffect>(),

--- a/src/test/kotlin/io/cyborgsquirrel/jobs/streaming/pi_client/PiClientWebSocketJobTest.kt
+++ b/src/test/kotlin/io/cyborgsquirrel/jobs/streaming/pi_client/PiClientWebSocketJobTest.kt
@@ -20,10 +20,8 @@ import io.cyborgsquirrel.lighting.effects.service.LightEffectRegistry
 import io.cyborgsquirrel.lighting.enums.BlendMode
 import io.cyborgsquirrel.lighting.enums.LightEffectStatus
 import io.cyborgsquirrel.lighting.model.LedStripPoolModel
-import io.cyborgsquirrel.lighting.model.RgbColor
 import io.cyborgsquirrel.lighting.model.SingleLedStripModel
 import io.cyborgsquirrel.lighting.rendering.LightEffectRenderer
-import io.cyborgsquirrel.lighting.rendering.model.RenderedFrameSegmentModel
 import io.cyborgsquirrel.util.time.TimeHelper
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
@@ -85,7 +83,7 @@ class PiClientWebSocketJobTest : StringSpec({
     )
     val activeEffect = ActiveLightEffect(
         effectUuid = "effect-uuid",
-        priority = 0,
+        layer = 0,
         skipFramesIfBlank = false,
         status = LightEffectStatus.Playing,
         effect = mockk<LightEffect>(),

--- a/src/test/kotlin/io/cyborgsquirrel/lighting/effects/controller/EffectControllerTest.kt
+++ b/src/test/kotlin/io/cyborgsquirrel/lighting/effects/controller/EffectControllerTest.kt
@@ -589,6 +589,7 @@ class EffectControllerTest(
                 effectSettings = nrSettingsEntity,
                 uuid = UUID.randomUUID().toString(),
                 status = LightEffectStatus.Inactive,
+                layer = 1,
             )
         )
 
@@ -854,5 +855,204 @@ class EffectControllerTest(
         val body = response.body() as List<*>
         // EffectApiServiceTest verifies details
         body.size shouldBe 8
+    }
+
+    "Create an effect with an explicit layer persists it and is reflected in the response" {
+        val client = createLedStripClientEntity(clientRepository, "Office lights", "192.168.50.60", 60, 61)
+        val strip = saveLedStrip(stripRepository, client, "Strip A", 60, PiClientPin.D21.pinName, 80)
+        val defaultNrSettings = objectToMap(objectMapper, NightriderColorFillEffectSettings())
+
+        val createResponse = apiClient.createEffect(
+            CreateEffectRequest(
+                stripUuid = strip.uuid,
+                poolUuid = null,
+                effectType = LightEffectType.NIGHTRIDER_COLOR_FILL.displayName,
+                name = "Layer 3 effect",
+                settings = defaultNrSettings,
+                paletteUuid = null,
+                settingsUuid = null,
+                layer = 3,
+            )
+        )
+        createResponse.status shouldBe HttpStatus.CREATED
+        val createdUuid = createResponse.body() as String
+
+        effectRepository.findByUuid(createdUuid).get().layer shouldBe 3
+
+        val getResponse = apiClient.getEffect(createdUuid)
+        getResponse.status shouldBe HttpStatus.OK
+        (getResponse.body() as GetStripEffectResponse).layer shouldBe 3
+    }
+
+    "Create an effect on the same strip with a duplicate layer is rejected" {
+        val client = createLedStripClientEntity(clientRepository, "Garage lights", "192.168.50.70", 70, 71)
+        val strip = saveLedStrip(stripRepository, client, "Strip A", 60, PiClientPin.D21.pinName, 80)
+        val defaultNrSettings = objectToMap(objectMapper, NightriderColorFillEffectSettings())
+
+        apiClient.createEffect(
+            CreateEffectRequest(
+                stripUuid = strip.uuid,
+                poolUuid = null,
+                effectType = LightEffectType.NIGHTRIDER_COLOR_FILL.displayName,
+                name = "First",
+                settings = defaultNrSettings,
+                paletteUuid = null,
+                settingsUuid = null,
+                layer = 0,
+            )
+        ).status shouldBe HttpStatus.CREATED
+
+        val secondResponse = apiClient.createEffect(
+            CreateEffectRequest(
+                stripUuid = strip.uuid,
+                poolUuid = null,
+                effectType = LightEffectType.NIGHTRIDER_COLOR_FILL.displayName,
+                name = "Second",
+                settings = defaultNrSettings,
+                paletteUuid = null,
+                settingsUuid = null,
+                layer = 0,
+            )
+        )
+
+        secondResponse.status shouldBe HttpStatus.BAD_REQUEST
+        effectRepository.queryAll().size shouldBe 1
+    }
+
+    "Create an effect without a layer auto-assigns the next free layer on the strip" {
+        val client = createLedStripClientEntity(clientRepository, "Kitchen lights", "192.168.50.80", 80, 81)
+        val strip = saveLedStrip(stripRepository, client, "Strip A", 60, PiClientPin.D21.pinName, 80)
+        val defaultNrSettings = objectToMap(objectMapper, NightriderColorFillEffectSettings())
+
+        fun create() = apiClient.createEffect(
+            CreateEffectRequest(
+                stripUuid = strip.uuid,
+                poolUuid = null,
+                effectType = LightEffectType.NIGHTRIDER_COLOR_FILL.displayName,
+                name = "Auto layer",
+                settings = defaultNrSettings,
+                paletteUuid = null,
+                settingsUuid = null,
+                layer = null,
+            )
+        )
+
+        val firstUuid = create().body() as String
+        val secondUuid = create().body() as String
+        val thirdUuid = create().body() as String
+
+        effectRepository.findByUuid(firstUuid).get().layer shouldBe 0
+        effectRepository.findByUuid(secondUuid).get().layer shouldBe 1
+        effectRepository.findByUuid(thirdUuid).get().layer shouldBe 2
+    }
+
+    "Create auto-layer slots above an explicitly assigned high layer" {
+        val client = createLedStripClientEntity(clientRepository, "Studio lights", "192.168.50.90", 90, 91)
+        val strip = saveLedStrip(stripRepository, client, "Strip A", 60, PiClientPin.D21.pinName, 80)
+        val defaultNrSettings = objectToMap(objectMapper, NightriderColorFillEffectSettings())
+
+        apiClient.createEffect(
+            CreateEffectRequest(
+                stripUuid = strip.uuid,
+                poolUuid = null,
+                effectType = LightEffectType.NIGHTRIDER_COLOR_FILL.displayName,
+                name = "Explicit layer 5",
+                settings = defaultNrSettings,
+                paletteUuid = null,
+                settingsUuid = null,
+                layer = 5,
+            )
+        ).status shouldBe HttpStatus.CREATED
+
+        val autoUuid = apiClient.createEffect(
+            CreateEffectRequest(
+                stripUuid = strip.uuid,
+                poolUuid = null,
+                effectType = LightEffectType.NIGHTRIDER_COLOR_FILL.displayName,
+                name = "Auto after 5",
+                settings = defaultNrSettings,
+                paletteUuid = null,
+                settingsUuid = null,
+                layer = null,
+            )
+        ).body() as String
+
+        effectRepository.findByUuid(autoUuid).get().layer shouldBe 6
+    }
+
+    "Patching an effect without a layer recomputes to max-of-other-effects + 1 on its strip" {
+        val client = createLedStripClientEntity(clientRepository, "Lab lights", "192.168.50.100", 100, 101)
+        val strip = saveLedStrip(stripRepository, client, "Strip A", 60, PiClientPin.D21.pinName, 80)
+        val defaultNrSettings = objectToMap(objectMapper, NightriderColorFillEffectSettings())
+
+        val anchorUuid = apiClient.createEffect(
+            CreateEffectRequest(
+                stripUuid = strip.uuid,
+                poolUuid = null,
+                effectType = LightEffectType.NIGHTRIDER_COLOR_FILL.displayName,
+                name = "Anchor on layer 4",
+                settings = defaultNrSettings,
+                paletteUuid = null,
+                settingsUuid = null,
+                layer = 4,
+            )
+        ).body() as String
+
+        val targetUuid = apiClient.createEffect(
+            CreateEffectRequest(
+                stripUuid = strip.uuid,
+                poolUuid = null,
+                effectType = LightEffectType.NIGHTRIDER_COLOR_FILL.displayName,
+                name = "Target on layer 1",
+                settings = defaultNrSettings,
+                paletteUuid = null,
+                settingsUuid = null,
+                layer = 1,
+            )
+        ).body() as String
+
+        apiClient.updateEffect(
+            targetUuid,
+            UpdateEffectRequest(
+                stripUuid = strip.uuid,
+                poolUuid = null,
+                paletteUuid = null,
+                settingsUuid = null,
+                name = null,
+                layer = null,
+            ),
+        ).status shouldBe HttpStatus.NO_CONTENT
+
+        effectRepository.findByUuid(anchorUuid).get().layer shouldBe 4
+        effectRepository.findByUuid(targetUuid).get().layer shouldBe 5
+    }
+
+    "Effect settings preserve skipFramesIfBlank through create and patch" {
+        val createBody = io.cyborgsquirrel.lighting.effects.requests.CreateEffectSettingsRequest(
+            type = LightEffectType.NIGHTRIDER_COLOR_FILL.displayName,
+            name = "Skip blank off",
+            settings = objectToMap(objectMapper, NightriderColorFillEffectSettings()),
+            isDefault = false,
+            skipFramesIfBlank = false,
+        )
+        val createResponse = apiClient.createEffectSettings(createBody)
+        createResponse.status shouldBe HttpStatus.CREATED
+        val settingsUuid = createResponse.body() as String
+
+        val initial = apiClient.getEffectSettings(settingsUuid).body()
+                as io.cyborgsquirrel.lighting.effects.responses.GetEffectSettingsResponse
+        initial.skipFramesIfBlank shouldBe false
+
+        val patchBody = io.cyborgsquirrel.lighting.effects.requests.UpdateEffectSettingsRequest(
+            name = null,
+            settings = null,
+            isDefault = null,
+            skipFramesIfBlank = true,
+        )
+        apiClient.updateEffectSettings(settingsUuid, patchBody).status shouldBe HttpStatus.NO_CONTENT
+
+        val patched = apiClient.getEffectSettings(settingsUuid).body()
+                as io.cyborgsquirrel.lighting.effects.responses.GetEffectSettingsResponse
+        patched.skipFramesIfBlank shouldBe true
     }
 })

--- a/src/test/kotlin/io/cyborgsquirrel/lighting/effects/repository/LightEffectRepositoryTest.kt
+++ b/src/test/kotlin/io/cyborgsquirrel/lighting/effects/repository/LightEffectRepositoryTest.kt
@@ -21,8 +21,10 @@ import io.cyborgsquirrel.lighting.enums.BlendMode
 import io.cyborgsquirrel.lighting.enums.LightEffectStatus
 import io.cyborgsquirrel.test_helpers.normalizeNumberTypes
 import io.cyborgsquirrel.test_helpers.objectToMap
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.micronaut.data.exceptions.DataAccessException
 import io.micronaut.serde.ObjectMapper
 import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
 import java.util.*
@@ -180,5 +182,187 @@ class LightEffectRepositoryTest(
         newEntities.size shouldBe 1
         verifyLightEffectEntity(newEntities.first(), lightEffect)
         newEntities.first().pool?.members?.first()?.id shouldBe poolMember.id
+    }
+
+    "layer and skipFramesIfBlank round-trip through persistence" {
+        val client = clientRepository.save(
+            LedStripClientEntity(
+                name = "Roundtrip client",
+                address = "192.168.1.2",
+                clientType = ClientType.Pi,
+                colorOrder = ColorOrder.RGB,
+                uuid = UUID.randomUUID().toString(),
+                apiPort = 1111,
+                wsPort = 2222,
+                firmwareVersion = "--",
+                fps = 35,
+                fadeTimeoutMillis = 0,
+            )
+        )
+        val strip = ledStripRepository.save(
+            LedStripEntity(
+                client = client,
+                uuid = UUID.randomUUID().toString(),
+                name = "Roundtrip strip",
+                pin = PiClientPin.D18.pinName,
+                length = 60,
+                blendMode = BlendMode.Average,
+                brightness = 25,
+            )
+        )
+        val settingsEntity = settingsRepository.save(
+            LightEffectSettingsEntity(
+                uuid = UUID.randomUUID().toString(),
+                type = LightEffectType.NIGHTRIDER_COLOR_FILL.displayName,
+                name = "Skip-blank-off settings",
+                settings = objectToMap(objectMapper, settings),
+                isDefault = false,
+                skipFramesIfBlank = false,
+            )
+        )
+        lightEffectRepository.save(
+            LightEffectEntity(
+                effectSettings = settingsEntity,
+                name = "Layer 7 effect",
+                strip = strip,
+                uuid = UUID.randomUUID().toString(),
+                status = LightEffectStatus.Inactive,
+                layer = 7,
+            )
+        )
+
+        val fetched = lightEffectRepository.queryAll().single()
+        fetched.layer shouldBe 7
+        fetched.effectSettings?.skipFramesIfBlank shouldBe false
+    }
+
+    "Duplicate layer on the same strip is rejected by the unique constraint" {
+        val client = clientRepository.save(
+            LedStripClientEntity(
+                name = "Dup-layer client",
+                address = "192.168.1.3",
+                clientType = ClientType.Pi,
+                colorOrder = ColorOrder.RGB,
+                uuid = UUID.randomUUID().toString(),
+                apiPort = 1111,
+                wsPort = 2222,
+                firmwareVersion = "--",
+                fps = 35,
+                fadeTimeoutMillis = 0,
+            )
+        )
+        val strip = ledStripRepository.save(
+            LedStripEntity(
+                client = client,
+                uuid = UUID.randomUUID().toString(),
+                name = "Dup-layer strip",
+                pin = PiClientPin.D18.pinName,
+                length = 60,
+                blendMode = BlendMode.Average,
+                brightness = 25,
+            )
+        )
+        val settingsEntity = settingsRepository.save(
+            LightEffectSettingsEntity(
+                uuid = UUID.randomUUID().toString(),
+                type = LightEffectType.NIGHTRIDER_COLOR_FILL.displayName,
+                name = "Settings",
+                settings = objectToMap(objectMapper, settings),
+                isDefault = false,
+            )
+        )
+        lightEffectRepository.save(
+            LightEffectEntity(
+                effectSettings = settingsEntity,
+                name = "First on layer 0",
+                strip = strip,
+                uuid = UUID.randomUUID().toString(),
+                status = LightEffectStatus.Inactive,
+                layer = 0,
+            )
+        )
+
+        shouldThrow<DataAccessException> {
+            lightEffectRepository.save(
+                LightEffectEntity(
+                    effectSettings = settingsEntity,
+                    name = "Second on layer 0",
+                    strip = strip,
+                    uuid = UUID.randomUUID().toString(),
+                    status = LightEffectStatus.Inactive,
+                    layer = 0,
+                )
+            )
+        }
+    }
+
+    "Same layer is allowed on different strips" {
+        val client = clientRepository.save(
+            LedStripClientEntity(
+                name = "Cross-strip client",
+                address = "192.168.1.4",
+                clientType = ClientType.Pi,
+                colorOrder = ColorOrder.RGB,
+                uuid = UUID.randomUUID().toString(),
+                apiPort = 1111,
+                wsPort = 2222,
+                firmwareVersion = "--",
+                fps = 35,
+                fadeTimeoutMillis = 0,
+            )
+        )
+        val stripA = ledStripRepository.save(
+            LedStripEntity(
+                client = client,
+                uuid = UUID.randomUUID().toString(),
+                name = "Strip A",
+                pin = PiClientPin.D18.pinName,
+                length = 60,
+                blendMode = BlendMode.Average,
+                brightness = 25,
+            )
+        )
+        val stripB = ledStripRepository.save(
+            LedStripEntity(
+                client = client,
+                uuid = UUID.randomUUID().toString(),
+                name = "Strip B",
+                pin = PiClientPin.D10.pinName,
+                length = 60,
+                blendMode = BlendMode.Average,
+                brightness = 25,
+            )
+        )
+        val settingsEntity = settingsRepository.save(
+            LightEffectSettingsEntity(
+                uuid = UUID.randomUUID().toString(),
+                type = LightEffectType.NIGHTRIDER_COLOR_FILL.displayName,
+                name = "Settings",
+                settings = objectToMap(objectMapper, settings),
+                isDefault = false,
+            )
+        )
+        lightEffectRepository.save(
+            LightEffectEntity(
+                effectSettings = settingsEntity,
+                name = "A layer 0",
+                strip = stripA,
+                uuid = UUID.randomUUID().toString(),
+                status = LightEffectStatus.Inactive,
+                layer = 0,
+            )
+        )
+        lightEffectRepository.save(
+            LightEffectEntity(
+                effectSettings = settingsEntity,
+                name = "B layer 0",
+                strip = stripB,
+                uuid = UUID.randomUUID().toString(),
+                status = LightEffectStatus.Inactive,
+                layer = 0,
+            )
+        )
+
+        lightEffectRepository.queryAll().size shouldBe 2
     }
 })

--- a/src/test/kotlin/io/cyborgsquirrel/test_helpers/DataCreationTestHelper.kt
+++ b/src/test/kotlin/io/cyborgsquirrel/test_helpers/DataCreationTestHelper.kt
@@ -68,6 +68,7 @@ fun saveLightEffect(
     settingsRepository: LightEffectSettingsRepository,
     strip: LedStripEntity,
     status: LightEffectStatus = LightEffectStatus.Inactive,
+    layer: Int = nextLayerForStrip(effectRepository, strip),
 ): LightEffectEntity {
     val settingsEntity = settingsRepository.save(
         LightEffectSettingsEntity(
@@ -85,6 +86,12 @@ fun saveLightEffect(
             name = "My light effect",
             status = status,
             effectSettings = settingsEntity,
+            layer = layer,
         )
     )
 }
+
+private fun nextLayerForStrip(
+    effectRepository: LightEffectRepository,
+    strip: LedStripEntity,
+): Int = (effectRepository.findByStrip(strip).maxOfOrNull { it.layer }?.plus(1)) ?: 0


### PR DESCRIPTION
### Layering

Layer numbers are unique for each effect assigned to a strip. Adding or editing defaults to assigning a layer equal to the highest layer number on the strip plus one.

### Skip if blank

Boolean flag allows the renderer to skip frames if they would be blank. This is useful for some effects when using filters that mirror the effect over the center of the strip because the blank half may be mirrored to both sides.

