### PR TITLE
Effects paused on server startup bugfixes

### DIFF
--- a/src/main/kotlin/io/cyborgsquirrel/jobs/streaming/nightdriver/NightDriverSocketJob.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/jobs/streaming/nightdriver/NightDriverSocketJob.kt
@@ -323,7 +323,7 @@ class NightDriverSocketJob(
                 is SingleLedStripModel -> strip.clientUuid == clientUuid
                 is LedStripPoolModel -> strip.clientUuids().contains(clientUuid)
             }
-        }.map { it.strip }
+        }.map { it.strip }.distinctBy { it.uuid }
 
         if (strips != matchingStrips) {
             // NightDriver has no settings-sync step, so the new strip list takes effect on the next rendered frame.

--- a/src/main/kotlin/io/cyborgsquirrel/jobs/streaming/pi_client/PiClientWebSocketJob.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/jobs/streaming/pi_client/PiClientWebSocketJob.kt
@@ -395,7 +395,7 @@ class PiClientWebSocketJob(
                 is SingleLedStripModel -> strip.clientUuid == clientUuid
                 is LedStripPoolModel -> strip.clientUuids().contains(clientUuid)
             }
-        }.map { it.strip }
+        }.map { it.strip }.distinctBy { it.uuid }
 
         if (strips != matchingStrips) {
             strips = matchingStrips

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/BouncingBallLightEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/BouncingBallLightEffect.kt
@@ -27,7 +27,7 @@ class BouncingBallLightEffect(
     private val dampening = 0.90
     private var iterations = 0
     private lateinit var backupColor: RgbColor
-    private var buffer = listOf<RgbColor>()
+    private var buffer = List(numberOfLeds) { RgbColor.Blank }
 
     override fun getNextStep(): List<RgbColor> {
         val ballLocation = getBallPosition()

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/FlameLightEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/FlameLightEffect.kt
@@ -14,7 +14,7 @@ import kotlin.random.Random
  * https://github.com/davepl/DavesGarageLEDSeries/blob/master/LED%20Episode%2011/include/fire.h
  */
 class FlameLightEffect(
-    private val numberOfLeds: Int,
+    numberOfLeds: Int,
     override val settings: FlameEffectSettings,
     override var palette: ColorPalette?,
     timeHelper: TimeHelper,
@@ -23,7 +23,7 @@ class FlameLightEffect(
     // TODO how do we count iterations? Do we count iterations for this effect?
     private var iterations = 0
     private val heat = IntArray(numberOfLeds)
-    private var buffer = listOf<RgbColor>()
+    private var buffer = List(numberOfLeds) { RgbColor.Blank }
 
     override fun getNextStep(): List<RgbColor> {
         if (!isUpdateDue(settings.updatesPerSecond)) return buffer

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/MarqueeEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/MarqueeEffect.kt
@@ -16,7 +16,7 @@ class MarqueeEffect(
     private var frame = 0
     private var iterations = 0
     private var shiftAmount = 0
-    private var buffer = listOf<RgbColor>()
+    private var buffer = List(numberOfLeds) { RgbColor.Blank }
 
     override fun getNextStep(): List<RgbColor> {
         if (buffer.isNotEmpty() && !isUpdateDue(settings.updatesPerSecond)) return buffer

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/SpectrumLightEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/SpectrumLightEffect.kt
@@ -19,7 +19,7 @@ class SpectrumLightEffect(
     private var iterations = 0
     private var referenceFrame = mutableListOf<RgbColor>()
     private val colorWidth = getColorWidth()
-    private var buffer = listOf<RgbColor>()
+    private var buffer = List(numberOfLeds) { RgbColor.Blank }
 
     override fun getNextStep(): List<RgbColor> {
         if (referenceFrame.isNotEmpty() && !isUpdateDue(settings.updatesPerSecond)) return buffer

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/WaveLightEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/WaveLightEffect.kt
@@ -27,7 +27,7 @@ class WaveLightEffect(
     private lateinit var waveB: Comet
     private val waveLength = settings.waveLength
     private val startPoint = (settings.startPointPercentage / 100.0 * numberOfLeds).toInt()
-    private var buffer = listOf<RgbColor>()
+    private var buffer = List(numberOfLeds) { RgbColor.Blank }
 
     override fun getNextStep(): List<RgbColor> {
         if (frame != 0 && !isUpdateDue(settings.updatesPerSecond)) return buffer


### PR DESCRIPTION
Changed effect classes to initialize buffers to match strip length. Fixed bug where effects paused at server startup would crash EffectsBlender. Fixed strips saving in socket jobs to de-duplicate strips.