### PR TITLE
CPU efficiency rendering tweaks

### DIFF
--- a/src/main/kotlin/io/cyborgsquirrel/jobs/streaming/nightdriver/NightDriverSocketJob.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/jobs/streaming/nightdriver/NightDriverSocketJob.kt
@@ -1,6 +1,7 @@
 package io.cyborgsquirrel.jobs.streaming.nightdriver
 
 import io.cyborgsquirrel.clients.entity.LedStripClientEntity
+import io.cyborgsquirrel.lighting.enums.EffectLengthMode
 import io.cyborgsquirrel.clients.repository.LedStripClientRepository
 import io.cyborgsquirrel.jobs.streaming.ClientStreamingJob
 import io.cyborgsquirrel.jobs.streaming.model.NightDriverStreamingJobState
@@ -156,7 +157,7 @@ class NightDriverSocketJob(
 
                 StreamingJobStatus.RenderingEffect -> {
                     triggerManager.processTriggers()
-                    val frameList = renderer.renderFrames(strips, clientEntity.uuid)
+                    val frameList = renderer.renderFrames(strips, clientEntity.uuid, EffectLengthMode.Truncate)
 
                     if (frameList.isEmpty()) {
                         // Sleep for the equivalent of 2 frames

--- a/src/main/kotlin/io/cyborgsquirrel/jobs/streaming/nightdriver/NightDriverSocketJob.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/jobs/streaming/nightdriver/NightDriverSocketJob.kt
@@ -59,7 +59,6 @@ class NightDriverSocketJob(
     private val bufferTimeMillis = 500L
     private var lastSeenAt = 0L
     private var sleepMillis = 0L
-    private var lastTimeSyncPerformedAt = 0L
     private val clientTimeSync = ClientTimeSync(timeHelper)
     private val clientTimeOffset: Long
         get() = clientTimeSync.mostRecentClientTimeOffset
@@ -181,13 +180,12 @@ class NightDriverSocketJob(
 
                         for (encodedFrame in encodedFrames) {
                             // Sync time once every 5 minutes
-                            val isTimeSyncFrame = lastTimeSyncPerformedAt + (1000 * 60 * 5) < now
+                            val isTimeSyncFrame = clientTimeSync.mostRecentTimeSyncPerformedAt + (1000 * 60 * 5) < now
 
                             if (isTimeSyncFrame) {
                                 clientTimeSync.doTimeSync {
                                     sendSocketFrame(encodedFrame)
                                     if (lastResponse != null) {
-                                        lastTimeSyncPerformedAt = now
                                         lastResponse!!.currentClockMillis()
                                     } else {
                                         -1

--- a/src/main/kotlin/io/cyborgsquirrel/jobs/streaming/pi_client/PiClientWebSocketJob.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/jobs/streaming/pi_client/PiClientWebSocketJob.kt
@@ -1,6 +1,7 @@
 package io.cyborgsquirrel.jobs.streaming.pi_client
 
 import io.cyborgsquirrel.clients.config.pi_client.PiClientSettings
+import io.cyborgsquirrel.lighting.enums.EffectLengthMode
 import io.cyborgsquirrel.clients.config.pi_client.PiClientStripConfig
 import io.cyborgsquirrel.clients.config.pi_client.PiConfigClient
 import io.cyborgsquirrel.clients.entity.LedStripClientEntity
@@ -180,7 +181,7 @@ class PiClientWebSocketJob(
                         status = StreamingJobStatus.TimeSyncRequired
                     } else {
                         triggerManager.processTriggers()
-                        val frames = renderer.renderFrames(strips, clientEntity.uuid)
+                        val frames = renderer.renderFrames(strips, clientEntity.uuid, EffectLengthMode.Permissive)
                         if (frames.isEmpty()) {
                             sendKeepaliveIfDue()
                             timestampMillis = currentTimeAsMillis + clientTimeSync.mostRecentClientTimeOffset

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/BouncingBallLightEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/BouncingBallLightEffect.kt
@@ -32,6 +32,9 @@ class BouncingBallLightEffect(
     private val checker = EffectUpdateTickChecker(timeHelper)
 
     override fun getNextStep(): List<RgbColor> {
+        // To save on CPU cycles don't update the bouncing ball sim more than 60 times per second
+        val updateDue = checker.isUpdateDue(60)
+        if (!updateDue) return buffer
         val ballLocation = getBallPosition()
         val rgbList = ArrayList<RgbColor>(numberOfLeds)
         for (i in 0..<ballLocation) {
@@ -50,9 +53,6 @@ class BouncingBallLightEffect(
         buffer = rgbList
         return rgbList
     }
-
-    // To save on CPU cycles don't update the bouncing ball sim more than 60 times per second
-    override fun isUpdateDue() = checker.isUpdateDue(60)
 
     override fun getBuffer(): List<RgbColor> = buffer
 

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/BouncingBallLightEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/BouncingBallLightEffect.kt
@@ -1,6 +1,7 @@
 package io.cyborgsquirrel.lighting.effects
 
 import io.cyborgsquirrel.lighting.effect_palette.palette.ColorPalette
+import io.cyborgsquirrel.lighting.effects.helpers.EffectUpdateTickChecker
 import io.cyborgsquirrel.lighting.effects.settings.BouncingBallEffectSettings
 import io.cyborgsquirrel.lighting.model.RgbColor
 import io.cyborgsquirrel.util.time.TimeHelper
@@ -28,10 +29,11 @@ class BouncingBallLightEffect(
     private var iterations = 0
     private lateinit var backupColor: RgbColor
     private var buffer = List(numberOfLeds) { RgbColor.Blank }
+    private val checker = EffectUpdateTickChecker(timeHelper)
 
     override fun getNextStep(): List<RgbColor> {
         val ballLocation = getBallPosition()
-        val rgbList = mutableListOf<RgbColor>()
+        val rgbList = ArrayList<RgbColor>(numberOfLeds)
         for (i in 0..<ballLocation) {
             rgbList.add(RgbColor.Blank)
         }
@@ -44,9 +46,13 @@ class BouncingBallLightEffect(
             rgbList.add(RgbColor.Blank)
         }
 
+        checker.onUpdate(timeHelper.millisSinceEpoch())
         buffer = rgbList
         return rgbList
     }
+
+    // To save on CPU cycles don't update the bouncing ball sim more than 60 times per second
+    override fun isUpdateDue() = checker.isUpdateDue(60)
 
     override fun getBuffer(): List<RgbColor> = buffer
 

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/CustomLightEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/CustomLightEffect.kt
@@ -22,8 +22,6 @@ class CustomLightEffect(
         TODO("Not yet implemented")
     }
 
-    override fun isUpdateDue(): Boolean = true
-
     override fun getIterations(): Int {
         TODO("Not yet implemented")
     }

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/CustomLightEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/CustomLightEffect.kt
@@ -22,6 +22,8 @@ class CustomLightEffect(
         TODO("Not yet implemented")
     }
 
+    override fun isUpdateDue(): Boolean = true
+
     override fun getIterations(): Int {
         TODO("Not yet implemented")
     }

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/FlameLightEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/FlameLightEffect.kt
@@ -1,6 +1,7 @@
 package io.cyborgsquirrel.lighting.effects
 
 import io.cyborgsquirrel.lighting.effect_palette.palette.ColorPalette
+import io.cyborgsquirrel.lighting.effects.helpers.EffectUpdateTickChecker
 import io.cyborgsquirrel.lighting.effects.settings.FlameEffectSettings
 import io.cyborgsquirrel.lighting.model.RgbColor
 import io.cyborgsquirrel.util.time.TimeHelper
@@ -24,14 +25,17 @@ class FlameLightEffect(
     private var iterations = 0
     private val heat = IntArray(numberOfLeds)
     private var buffer = List(numberOfLeds) { RgbColor.Blank }
+    private val checker = EffectUpdateTickChecker(timeHelper)
 
     override fun getNextStep(): List<RgbColor> {
-        if (!isUpdateDue(settings.updatesPerSecond)) return buffer
         buffer = drawFire()
+        checker.onUpdate(timeHelper.millisSinceEpoch())
         return buffer
     }
 
     override fun getBuffer(): List<RgbColor> = buffer
+
+    override fun isUpdateDue(): Boolean = checker.isUpdateDue(settings.updatesPerSecond)
 
     override fun getIterations() = iterations
 
@@ -62,7 +66,7 @@ class FlameLightEffect(
         }
 
         // Convert heat to color
-        val rgbList = mutableListOf<RgbColor>()
+        val rgbList = ArrayList<RgbColor>(heat.size)
         for (i in heat.indices) {
             val color = getColor(heat[heat.size - 1 - i], i)
             rgbList.add(color)

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/FlameLightEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/FlameLightEffect.kt
@@ -28,14 +28,15 @@ class FlameLightEffect(
     private val checker = EffectUpdateTickChecker(timeHelper)
 
     override fun getNextStep(): List<RgbColor> {
+        // To save on CPU cycles don't update the bouncing ball sim more than 60 times per second
+        val updateDue = checker.isUpdateDue(60)
+        if (!updateDue) return buffer
         buffer = drawFire()
         checker.onUpdate(timeHelper.millisSinceEpoch())
         return buffer
     }
 
     override fun getBuffer(): List<RgbColor> = buffer
-
-    override fun isUpdateDue(): Boolean = checker.isUpdateDue(settings.updatesPerSecond)
 
     override fun getIterations() = iterations
 

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/LightEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/LightEffect.kt
@@ -13,8 +13,6 @@ sealed class LightEffect(
 
     abstract fun getNextStep(): List<RgbColor>
 
-    abstract fun isUpdateDue(): Boolean
-
     abstract fun getBuffer(): List<RgbColor>
 
     abstract fun getIterations(): Int

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/LightEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/LightEffect.kt
@@ -11,18 +11,9 @@ sealed class LightEffect(
     protected val timeHelper: TimeHelper,
 ) {
 
-    protected var lastUpdatedMillis = 0L
-
-    protected fun isUpdateDue(updatesPerSecond: Int): Boolean {
-        val nowMillis = timeHelper.millisSinceEpoch()
-        if ((nowMillis - lastUpdatedMillis) > 1000L / updatesPerSecond) {
-            lastUpdatedMillis = nowMillis
-            return true
-        }
-        return false
-    }
-
     abstract fun getNextStep(): List<RgbColor>
+
+    abstract fun isUpdateDue(): Boolean
 
     abstract fun getBuffer(): List<RgbColor>
 

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/MarqueeEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/MarqueeEffect.kt
@@ -2,6 +2,7 @@ package io.cyborgsquirrel.lighting.effects
 
 import io.cyborgsquirrel.lighting.effect_palette.palette.ColorPalette
 import io.cyborgsquirrel.lighting.effects.settings.MarqueeEffectSettings
+import io.cyborgsquirrel.lighting.effects.helpers.EffectUpdateTickChecker
 import io.cyborgsquirrel.lighting.model.RgbColor
 import io.cyborgsquirrel.util.shift
 import io.cyborgsquirrel.util.time.TimeHelper
@@ -17,13 +18,13 @@ class MarqueeEffect(
     private var iterations = 0
     private var shiftAmount = 0
     private var buffer = List(numberOfLeds) { RgbColor.Blank }
+    private val checker = EffectUpdateTickChecker(timeHelper)
 
     override fun getNextStep(): List<RgbColor> {
-        if (buffer.isNotEmpty() && !isUpdateDue(settings.updatesPerSecond)) return buffer
         shiftAmount = (shiftAmount + 1) % numberOfLeds
 
         val dotList = mutableListOf<Boolean>()
-        val rgbList = mutableListOf<RgbColor>()
+        val rgbList = ArrayList<RgbColor>(numberOfLeds)
         var drawingDot = true
         var dotStart = 0
         var spaceStart = 0
@@ -64,10 +65,13 @@ class MarqueeEffect(
 
         frame++
         buffer = rgbList
+        checker.onUpdate(timeHelper.millisSinceEpoch())
         return rgbList
     }
 
     override fun getBuffer(): List<RgbColor> = buffer
+
+    override fun isUpdateDue(): Boolean = checker.isUpdateDue(settings.updatesPerSecond)
 
     override fun getIterations() = iterations
 

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/MarqueeEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/MarqueeEffect.kt
@@ -57,7 +57,7 @@ class MarqueeEffect(
 
         val shiftedDotList = dotList.shift(shiftAmount)
 
-        for (indx in shiftedDotList.indices) {
+        for (indx in 0..<numberOfLeds) {
             if (shiftedDotList[indx]) {
                 rgbList.add(getColor(indx))
             } else {

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/MarqueeEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/MarqueeEffect.kt
@@ -21,6 +21,8 @@ class MarqueeEffect(
     private val checker = EffectUpdateTickChecker(timeHelper)
 
     override fun getNextStep(): List<RgbColor> {
+        val updateDue = checker.isUpdateDue(settings.updatesPerSecond)
+        if (!updateDue) return buffer
         shiftAmount = (shiftAmount + 1) % numberOfLeds
 
         val dotList = mutableListOf<Boolean>()
@@ -70,8 +72,6 @@ class MarqueeEffect(
     }
 
     override fun getBuffer(): List<RgbColor> = buffer
-
-    override fun isUpdateDue(): Boolean = checker.isUpdateDue(settings.updatesPerSecond)
 
     override fun getIterations() = iterations
 

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/NightriderLightEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/NightriderLightEffect.kt
@@ -34,6 +34,8 @@ class NightriderLightEffect(
     private val checker = EffectUpdateTickChecker(timeHelper)
 
     override fun getNextStep(): List<RgbColor> {
+        val updateDue = checker.isUpdateDue(settings.updatesPerSecond)
+        if (!updateDue) return buffer
         onNextStep()
 
         buffer = when (settings) {
@@ -48,8 +50,6 @@ class NightriderLightEffect(
     }
 
     override fun getBuffer(): List<RgbColor> = buffer
-
-    override fun isUpdateDue(): Boolean = checker.isUpdateDue(settings.updatesPerSecond)
 
     private fun renderNightriderComet(): List<RgbColor> {
         return if (settings is NightriderCometEffectSettings) {

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/NightriderLightEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/NightriderLightEffect.kt
@@ -4,6 +4,7 @@ import io.cyborgsquirrel.lighting.effect_palette.palette.ColorPalette
 import io.cyborgsquirrel.lighting.effects.settings.NightriderColorFillEffectSettings
 import io.cyborgsquirrel.lighting.effects.settings.NightriderCometEffectSettings
 import io.cyborgsquirrel.lighting.effects.settings.NightriderEffectSettings
+import io.cyborgsquirrel.lighting.effects.helpers.EffectUpdateTickChecker
 import io.cyborgsquirrel.lighting.enums.FadeCurve
 import io.cyborgsquirrel.lighting.model.RgbColor
 import io.cyborgsquirrel.util.time.TimeHelper
@@ -30,9 +31,9 @@ class NightriderLightEffect(
     private var location = 0
     private var iterations = 0
     private var buffer = List(numberOfLeds) { RgbColor.Blank }
+    private val checker = EffectUpdateTickChecker(timeHelper)
 
     override fun getNextStep(): List<RgbColor> {
-        if (!isUpdateDue(settings.updatesPerSecond)) return buffer
         onNextStep()
 
         buffer = when (settings) {
@@ -42,14 +43,17 @@ class NightriderLightEffect(
 
         previousLocation = location
         frame++
+        checker.onUpdate(timeHelper.millisSinceEpoch())
         return buffer
     }
 
     override fun getBuffer(): List<RgbColor> = buffer
 
+    override fun isUpdateDue(): Boolean = checker.isUpdateDue(settings.updatesPerSecond)
+
     private fun renderNightriderComet(): List<RgbColor> {
         return if (settings is NightriderCometEffectSettings) {
-            val rgbList = mutableListOf<RgbColor>()
+            val rgbList = ArrayList<RgbColor>(numberOfLeds)
 
             if (location > 0) {
                 // Before comet
@@ -62,7 +66,7 @@ class NightriderLightEffect(
             val dotScaleFactor = 1.5f
             val dotColor = getColor(location, iterations).scale(dotScaleFactor)
 
-            val cometBuffer = mutableListOf<RgbColor>()
+            val cometBuffer = ArrayList<RgbColor>(settings.trailLength + 2)
             // Brightest spot is at the beginning for the reflect scenario
             if (reflect) {
                 cometBuffer.add(dotColor)
@@ -104,7 +108,7 @@ class NightriderLightEffect(
     }
 
     private fun renderNightriderColorFill(): List<RgbColor> {
-        val rgbList = mutableListOf<RgbColor>()
+        val rgbList = ArrayList<RgbColor>(numberOfLeds)
         val brightnessScaling = if (settings is NightriderColorFillEffectSettings) settings.brightnessScaling else 1f
         for (i in 0..<previousLocation) {
             if (reflect) {

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/SparkleLightEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/SparkleLightEffect.kt
@@ -33,6 +33,8 @@ class SparkleLightEffect(
     private val checker = EffectUpdateTickChecker(timeHelper)
 
     override fun getNextStep(): List<RgbColor> {
+        val updateDue = checker.isUpdateDue(settings.updatesPerSecond)
+        if (!updateDue) return buffer
         val now = timeHelper.millisSinceEpoch()
 
         val iterator = dots.iterator()
@@ -72,8 +74,6 @@ class SparkleLightEffect(
     }
 
     override fun getBuffer(): List<RgbColor> = buffer
-
-    override fun isUpdateDue(): Boolean = checker.isUpdateDue(settings.updatesPerSecond)
 
     override fun getIterations(): Int = iterations
 

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/SparkleLightEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/SparkleLightEffect.kt
@@ -2,6 +2,7 @@ package io.cyborgsquirrel.lighting.effects
 
 import io.cyborgsquirrel.lighting.effect_palette.palette.ColorPalette
 import io.cyborgsquirrel.lighting.effects.settings.SparkleEffectSettings
+import io.cyborgsquirrel.lighting.effects.helpers.EffectUpdateTickChecker
 import io.cyborgsquirrel.lighting.model.RgbColor
 import io.cyborgsquirrel.util.time.TimeHelper
 import kotlin.random.Random
@@ -29,10 +30,10 @@ class SparkleLightEffect(
     private val dots = mutableListOf<Dot>()
     private var buffer = MutableList(numberOfLeds) { RgbColor.Blank }
     private var iterations = 0
+    private val checker = EffectUpdateTickChecker(timeHelper)
 
     override fun getNextStep(): List<RgbColor> {
-        if (!isUpdateDue(settings.updatesPerSecond)) return buffer
-        val now = lastUpdatedMillis
+        val now = timeHelper.millisSinceEpoch()
 
         val iterator = dots.iterator()
         while (iterator.hasNext()) {
@@ -66,10 +67,13 @@ class SparkleLightEffect(
         }
 
         iterations++
+        checker.onUpdate(now)
         return buffer
     }
 
     override fun getBuffer(): List<RgbColor> = buffer
+
+    override fun isUpdateDue(): Boolean = checker.isUpdateDue(settings.updatesPerSecond)
 
     override fun getIterations(): Int = iterations
 

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/SpectrumLightEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/SpectrumLightEffect.kt
@@ -3,6 +3,7 @@ package io.cyborgsquirrel.lighting.effects
 import io.cyborgsquirrel.lighting.effect_palette.palette.ColorPalette
 import io.cyborgsquirrel.lighting.effect_palette.palette.GradientColorPalette
 import io.cyborgsquirrel.lighting.effects.settings.SpectrumEffectSettings
+import io.cyborgsquirrel.lighting.effects.helpers.EffectUpdateTickChecker
 import io.cyborgsquirrel.lighting.model.RgbColor
 import io.cyborgsquirrel.util.shift
 import io.cyborgsquirrel.util.time.TimeHelper
@@ -20,11 +21,14 @@ class SpectrumLightEffect(
     private var referenceFrame = mutableListOf<RgbColor>()
     private val colorWidth = getColorWidth()
     private var buffer = List(numberOfLeds) { RgbColor.Blank }
+    private val checker = EffectUpdateTickChecker(timeHelper)
 
     override fun getNextStep(): List<RgbColor> {
-        if (referenceFrame.isNotEmpty() && !isUpdateDue(settings.updatesPerSecond)) return buffer
+        // getNextStep always advances now (the renderer gates on isUpdateDue), and it has several exit paths, so
+        // record the update once up front.
+        checker.onUpdate(timeHelper.millisSinceEpoch())
 
-        val rgbList = mutableListOf<RgbColor>()
+        val rgbList = ArrayList<RgbColor>(numberOfLeds)
         val repeatOfColorsCount = ceil((numberOfLeds.toFloat() / colorWidth)).toInt()
 
         if (referenceFrame.isEmpty()) {
@@ -76,6 +80,8 @@ class SpectrumLightEffect(
     }
 
     override fun getBuffer(): List<RgbColor> = buffer
+
+    override fun isUpdateDue(): Boolean = checker.isUpdateDue(settings.updatesPerSecond)
 
     private fun colorList(index: Int): List<RgbColor> {
         if (palette != null) {

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/SpectrumLightEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/SpectrumLightEffect.kt
@@ -24,6 +24,8 @@ class SpectrumLightEffect(
     private val checker = EffectUpdateTickChecker(timeHelper)
 
     override fun getNextStep(): List<RgbColor> {
+        val updateDue = checker.isUpdateDue(settings.updatesPerSecond)
+        if (!updateDue) return buffer
         // getNextStep always advances now (the renderer gates on isUpdateDue), and it has several exit paths, so
         // record the update once up front.
         checker.onUpdate(timeHelper.millisSinceEpoch())
@@ -80,8 +82,6 @@ class SpectrumLightEffect(
     }
 
     override fun getBuffer(): List<RgbColor> = buffer
-
-    override fun isUpdateDue(): Boolean = checker.isUpdateDue(settings.updatesPerSecond)
 
     private fun colorList(index: Int): List<RgbColor> {
         if (palette != null) {

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/WaveLightEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/WaveLightEffect.kt
@@ -32,6 +32,8 @@ class WaveLightEffect(
     private val checker = EffectUpdateTickChecker(timeHelper)
 
     override fun getNextStep(): List<RgbColor> {
+        val updateDue = checker.isUpdateDue(settings.updatesPerSecond)
+        if (!updateDue) return buffer
         val rgbData = ArrayList<RgbColor>(numberOfLeds)
         if (waveALocation <= -waveLength && waveBLocation >= numberOfLeds + waveLength) {
             iterations++
@@ -77,8 +79,6 @@ class WaveLightEffect(
     }
 
     override fun getBuffer(): List<RgbColor> = buffer
-
-    override fun isUpdateDue(): Boolean = checker.isUpdateDue(settings.updatesPerSecond)
 
     override fun getIterations() = iterations
 

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/WaveLightEffect.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/WaveLightEffect.kt
@@ -2,6 +2,7 @@ package io.cyborgsquirrel.lighting.effects
 
 import io.cyborgsquirrel.lighting.effect_palette.palette.ColorPalette
 import io.cyborgsquirrel.lighting.effects.settings.WaveEffectSettings
+import io.cyborgsquirrel.lighting.effects.helpers.EffectUpdateTickChecker
 import io.cyborgsquirrel.lighting.effects.shared.Comet
 import io.cyborgsquirrel.lighting.enums.Direction
 import io.cyborgsquirrel.lighting.enums.FadeCurve
@@ -28,11 +29,10 @@ class WaveLightEffect(
     private val waveLength = settings.waveLength
     private val startPoint = (settings.startPointPercentage / 100.0 * numberOfLeds).toInt()
     private var buffer = List(numberOfLeds) { RgbColor.Blank }
+    private val checker = EffectUpdateTickChecker(timeHelper)
 
     override fun getNextStep(): List<RgbColor> {
-        if (frame != 0 && !isUpdateDue(settings.updatesPerSecond)) return buffer
-
-        val rgbData = mutableListOf<RgbColor>()
+        val rgbData = ArrayList<RgbColor>(numberOfLeds)
         if (waveALocation <= -waveLength && waveBLocation >= numberOfLeds + waveLength) {
             iterations++
             waveALocation = startPoint - 1
@@ -72,10 +72,13 @@ class WaveLightEffect(
 
         frame++
         buffer = rgbData
+        checker.onUpdate(timeHelper.millisSinceEpoch())
         return rgbData
     }
 
     override fun getBuffer(): List<RgbColor> = buffer
+
+    override fun isUpdateDue(): Boolean = checker.isUpdateDue(settings.updatesPerSecond)
 
     override fun getIterations() = iterations
 

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/helpers/EffectUpdateTickChecker.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/helpers/EffectUpdateTickChecker.kt
@@ -1,0 +1,17 @@
+package io.cyborgsquirrel.lighting.effects.helpers
+
+import io.cyborgsquirrel.util.time.TimeHelper
+
+class EffectUpdateTickChecker(private val timeHelper: TimeHelper) {
+
+    var lastUpdatedAtMillis: Long = 0
+
+    fun isUpdateDue(updatesPerSecond: Int): Boolean {
+        val nowMillis = timeHelper.millisSinceEpoch()
+        return (nowMillis - lastUpdatedAtMillis) > 1000L / updatesPerSecond
+    }
+
+    fun onUpdate(updatedAtMillis: Long) {
+        lastUpdatedAtMillis = updatedAtMillis
+    }
+}

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/service/LightEffectRegistryImpl.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/service/LightEffectRegistryImpl.kt
@@ -18,6 +18,11 @@ import kotlin.concurrent.withLock
 class LightEffectRegistryImpl : LightEffectRegistry {
     private val sink: Sinks.Many<List<ActiveLightEffect>> = Sinks.many().multicast().onBackpressureBuffer()
     private val effectListRef = AtomicReference(listOf<ActiveLightEffect>())
+
+    // Effects grouped by strip uuid, rebuilt only when the effect set changes. This keeps the per-frame render path
+    // off the global effect list, and the per-strip list instance is stable between changes so the renderer can use
+    // its identity to detect that a strip's effects are unchanged.
+    private val effectsByStripRef = AtomicReference(mapOf<String, List<ActiveLightEffect>>())
     private val writeLock = ReentrantLock()
 
     override val updates: Flux<List<ActiveLightEffect>> = sink.asFlux()
@@ -32,7 +37,7 @@ class LightEffectRegistryImpl : LightEffectRegistry {
                 logger.info("Updating light effect $lightEffect")
                 current.map { if (it.effectUuid == lightEffect.effectUuid) lightEffect else it }
             }
-            effectListRef.set(updated)
+            setEffects(updated)
             updated
         }
         sink.tryEmitNext(snapshot)
@@ -42,7 +47,7 @@ class LightEffectRegistryImpl : LightEffectRegistry {
         val snapshot: List<ActiveLightEffect> = writeLock.withLock {
             logger.info("Removing light effect $lightEffect")
             val updated = effectListRef.get() - lightEffect
-            effectListRef.set(updated)
+            setEffects(updated)
             updated
         }
         sink.tryEmitNext(snapshot)
@@ -59,15 +64,21 @@ class LightEffectRegistryImpl : LightEffectRegistry {
         }
 
     override fun getAllEffectsForStrip(stripUuid: String): List<ActiveLightEffect> =
-        effectListRef.get().filter { it.strip.uuid == stripUuid }
+        effectsByStripRef.get()[stripUuid] ?: emptyList()
 
     override fun getAllEffects(): List<ActiveLightEffect> = effectListRef.get()
 
     override fun removeAllEffects() {
         writeLock.withLock {
-            effectListRef.set(emptyList())
+            setEffects(emptyList())
         }
         sink.tryEmitNext(emptyList())
+    }
+
+    /** Must be called while holding [writeLock]. Updates the effect list and the strip index together. */
+    private fun setEffects(effects: List<ActiveLightEffect>) {
+        effectListRef.set(effects)
+        effectsByStripRef.set(effects.groupBy { it.strip.uuid })
     }
 
     companion object {

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/shared/Comet.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/shared/Comet.kt
@@ -8,7 +8,7 @@ import kotlin.math.max
 
 class Comet(val color: RgbColor, val length: Int, val fadeCurve: FadeCurve, val direction: Direction) {
 
-    private val cometBuffer = mutableListOf<RgbColor>()
+    private val cometBuffer = ArrayList<RgbColor>(length)
 
     val buffer: MutableList<RgbColor>
         get() = cometBuffer

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/enums/EffectLengthMode.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/enums/EffectLengthMode.kt
@@ -1,0 +1,18 @@
+package io.cyborgsquirrel.lighting.enums
+
+/**
+ * Instructs the [io.cyborgsquirrel.lighting.rendering.LightEffectRenderer] how to handle effects
+ * whose rendered RGB output length does not match the length of the LED strip.
+ */
+enum class EffectLengthMode {
+    // Truncate effect output that is longer than the strip down to the strip length. A warning is
+    // logged whenever output is actually truncated.
+    Truncate,
+
+    // Drop (ignore) any effect whose output length does not exactly equal the strip length. A
+    // warning is logged whenever an effect is ignored.
+    Ignore,
+
+    // Allow effect output of any length to pass through unchanged.
+    Permissive,
+}

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/filters/IntensityFadeFilter.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/filters/IntensityFadeFilter.kt
@@ -27,32 +27,23 @@ open class IntensityFadeFilter(
      * Scales the list of [RgbColor] from [startingIntensity] to the [endingIntensity] value.
      */
     override fun apply(rgbList: List<RgbColor>): List<RgbColor> {
-        val millisSinceEpoch = timeHelper.millisSinceEpoch()
-        return if (startTimeEpochMillis == 0L) {
-            startTimeEpochMillis = millisSinceEpoch
-            return rgbList.map {
-                it.scale(if (settings.fadeDuration.toMillis() == 0L) endingIntensity else startingIntensity)
-            }
-        } else {
-            if (startTimeEpochMillis + settings.fadeDuration.toMillis() < millisSinceEpoch) {
-                rgbList.map {
-                    it.scale(endingIntensity)
-                }
-            } else {
-                val millisSinceStart = millisSinceEpoch - startTimeEpochMillis
-                val percentComplete = millisSinceStart.toFloat() / fadeDuration.toMillis()
-                val startingIntensityList = rgbList.map {
-                    it.scale(startingIntensity)
-                }
-                val endingIntensityList = rgbList.map {
-                    it.scale(endingIntensity)
-                }
-                val currentIntensityList = startingIntensityList.mapIndexed { index, rgbColor ->
-                    rgbColor.interpolate(endingIntensityList[index], percentComplete)
-                }
+        // Interpolating per channel and then blending the two scaled buffers is equivalent to scaling once by the
+        // interpolated intensity, so compute a single factor and apply it in one pass.
+        val intensity = currentIntensity()
+        return rgbList.map { it.scale(intensity) }
+    }
 
-                currentIntensityList
-            }
+    private fun currentIntensity(): Float {
+        val millisSinceEpoch = timeHelper.millisSinceEpoch()
+        val fadeDurationMillis = fadeDuration.toMillis()
+        if (startTimeEpochMillis == 0L) {
+            startTimeEpochMillis = millisSinceEpoch
+            return if (fadeDurationMillis == 0L) endingIntensity else startingIntensity
         }
+        if (startTimeEpochMillis + fadeDurationMillis < millisSinceEpoch) {
+            return endingIntensity
+        }
+        val percentComplete = (millisSinceEpoch - startTimeEpochMillis).toFloat() / fadeDurationMillis
+        return startingIntensity + (endingIntensity - startingIntensity) * percentComplete
     }
 }

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/model/RgbColor.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/model/RgbColor.kt
@@ -44,7 +44,13 @@ data class RgbColor(val red: UByte, val green: UByte, val blue: UByte) {
     }
 
     operator fun plus(other: RgbColor): RgbColor {
-        return RgbColor((red + other.red).toUByte(), (green + other.green).toUByte(), (blue + other.blue).toUByte())
+        // Saturating add — channels clamp at the max value instead of wrapping around (e.g. additive blending).
+        val max = UByte.MAX_VALUE.toUInt()
+        return RgbColor(
+            minOf(red + other.red, max).toUByte(),
+            minOf(green + other.green, max).toUByte(),
+            minOf(blue + other.blue, max).toUByte(),
+        )
     }
 
     operator fun div(denominator: UInt): RgbColor {

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/rendering/LightEffectRenderer.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/rendering/LightEffectRenderer.kt
@@ -1,5 +1,6 @@
 package io.cyborgsquirrel.lighting.rendering
 
+import io.cyborgsquirrel.lighting.enums.EffectLengthMode
 import io.cyborgsquirrel.lighting.model.LedStripModel
 import io.cyborgsquirrel.lighting.rendering.model.RenderedFrameSegmentModel
 
@@ -8,5 +9,15 @@ import io.cyborgsquirrel.lighting.rendering.model.RenderedFrameSegmentModel
  */
 interface LightEffectRenderer {
 
-    fun renderFrames(strips: List<LedStripModel>, clientUuid: String): List<RenderedFrameSegmentModel>
+    /**
+     * Renders all active light effects for the specified LED [strips].
+     *
+     * [lengthMode] controls how effects whose output length does not match the strip length are
+     * handled (truncated, ignored, or allowed through).
+     */
+    fun renderFrames(
+        strips: List<LedStripModel>,
+        clientUuid: String,
+        lengthMode: EffectLengthMode = EffectLengthMode.Permissive,
+    ): List<RenderedFrameSegmentModel>
 }

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/rendering/LightEffectRendererImpl.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/rendering/LightEffectRendererImpl.kt
@@ -16,14 +16,17 @@ import io.cyborgsquirrel.lighting.rendering.post_processing.EffectsBlender
 import io.cyborgsquirrel.lighting.rendering.post_processing.FrameSegmentationHelper
 import jakarta.inject.Singleton
 import org.slf4j.LoggerFactory
-import java.util.concurrent.Semaphore
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 @Singleton
 class LightEffectRendererImpl(
     private val effectRepository: LightEffectRegistry,
 ) : LightEffectRenderer {
 
-    private val lock = Semaphore(1)
+    // Per-pool locks so independent pools render concurrently; only jobs sharing a pool serialize against each other.
+    private val poolLocks = ConcurrentHashMap<String, ReentrantLock>()
     private val cache = StripPoolFrameCache()
     private val tracker = ClientSequenceTracker()
     private val segmentationHelper = FrameSegmentationHelper()
@@ -37,10 +40,10 @@ class LightEffectRendererImpl(
         for (strip in strips) {
             when (strip) {
                 is LedStripPoolModel -> {
-                    try {
-                        /// Semaphore because strip pools can involve multiple clients and thus multiple job threads
-                        /// jobs should either get the latest frame or the frame cached from the other job's render sequence
-                        lock.acquire()
+                    /// Per-pool lock because strip pools can involve multiple clients and thus multiple job threads
+                    /// jobs should either get the latest frame or the frame cached from the other job's render sequence
+                    val poolLock = poolLocks.getOrPut(strip.uuid) { ReentrantLock() }
+                    poolLock.withLock {
                         val sequenceNumber = tracker.getSequenceNumber(clientUuid, strip.uuid)
                         tracker.setSequenceNumber(clientUuid, strip.uuid, (sequenceNumber + 1).toShort())
                         val cachedFrame = checkCache(strip, sequenceNumber)
@@ -60,8 +63,6 @@ class LightEffectRendererImpl(
                             val frameSegments = segmentationHelper.segmentFrame(strips, clientUuid, renderedFrame)
                             frameList.addAll(frameSegments)
                         }
-                    } finally {
-                        lock.release()
                     }
                 }
 
@@ -96,8 +97,8 @@ class LightEffectRendererImpl(
     }
 
     private fun renderFrame(strip: LedStripModel): RenderedFrameModel? {
-        val activeEffects =
-            effectRepository.getAllEffectsForStrip(strip.uuid).filter { it.status.isInUse() }.sortedBy { it.layer }
+        val effectsForStrip = effectRepository.getAllEffectsForStrip(strip.uuid)
+        val activeEffects = effectsForStrip.filter { it.status.isInUse() }.sortedBy { it.layer }
         return if (activeEffects.isEmpty()) {
             null
         } else {
@@ -109,36 +110,30 @@ class LightEffectRendererImpl(
         strip: LedStripModel,
         activeEffects: List<ActiveLightEffect>
     ): RenderedFrameModel {
-        val allEffectsRgbData = mutableListOf<List<RgbColor>>()
-        val activeEffectsByLayer = activeEffects.sortedBy { it.layer }
-        for (activeEffect in activeEffectsByLayer) {
+        val allEffectsRgbData = ArrayList<List<RgbColor>>(activeEffects.size)
+        for (activeEffect in activeEffects) {
             logger.debug("Rendering effect {}", activeEffect)
-            var rgbData = if (activeEffect.status == LightEffectStatus.Playing) {
-                activeEffect.effect.getNextStep()
-            } else {
-                activeEffect.effect.getBuffer()
-            }
+            // Advance the effect only when it is playing and due for an update; otherwise reuse its current buffer.
+            // This is where per-effect throttling (updatesPerSecond) happens.
+            val due = activeEffect.status == LightEffectStatus.Playing && activeEffect.effect.isUpdateDue()
+            var rgbData = if (due) activeEffect.effect.getNextStep() else activeEffect.effect.getBuffer()
+
             for (filter in activeEffect.filters) {
-                logger.debug("Applying filter ${filter.uuid}")
+                logger.debug("Applying filter {}", filter.uuid)
                 rgbData = filter.apply(rgbData)
             }
 
-            if (activeEffect.skipFramesIfBlank && activeEffect.status == LightEffectStatus.Playing) {
-                var allBlank = true
-                while (allBlank) {
-                    for (data in rgbData) {
-                        allBlank = allBlank && data == RgbColor.Blank
+            if (activeEffect.skipFramesIfBlank && due) {
+                var skipped = 0
+                while (skipped < MAX_BLANK_FRAME_SKIPS && rgbData.all { it.isBlank() }) {
+                    logger.debug(
+                        "All frames are blank and effect {} is set to skip blank frames", activeEffect.effectUuid
+                    )
+                    rgbData = activeEffect.effect.getNextStep()
+                    for (filter in activeEffect.filters) {
+                        rgbData = filter.apply(rgbData)
                     }
-
-                    if (allBlank) {
-                        logger.debug(
-                            "All frames are blank and effect {} is set to skip blank frames", activeEffect.effectUuid
-                        )
-                        rgbData = activeEffect.effect.getNextStep()
-                        for (filter in activeEffect.filters) {
-                            rgbData = filter.apply(rgbData)
-                        }
-                    }
+                    skipped++
                 }
             }
 
@@ -151,6 +146,9 @@ class LightEffectRendererImpl(
     }
 
     companion object {
+        // Safety bound so an effect that always renders blank can't spin the render loop forever.
+        // 4 seconds at 30 fps = 120
+        private const val MAX_BLANK_FRAME_SKIPS = 120
         private val logger = LoggerFactory.getLogger(LightEffectRendererImpl::class.java)
     }
 }

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/rendering/LightEffectRendererImpl.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/rendering/LightEffectRendererImpl.kt
@@ -113,17 +113,15 @@ class LightEffectRendererImpl(
         val allEffectsRgbData = ArrayList<List<RgbColor>>(activeEffects.size)
         for (activeEffect in activeEffects) {
             logger.debug("Rendering effect {}", activeEffect)
-            // Advance the effect only when it is playing and due for an update; otherwise reuse its current buffer.
-            // This is where per-effect throttling (updatesPerSecond) happens.
-            val due = activeEffect.status == LightEffectStatus.Playing
-            var rgbData = if (due) activeEffect.effect.getNextStep() else activeEffect.effect.getBuffer()
+            val playing = activeEffect.status == LightEffectStatus.Playing
+            var rgbData = if (playing) activeEffect.effect.getNextStep() else activeEffect.effect.getBuffer()
 
             for (filter in activeEffect.filters) {
                 logger.debug("Applying filter {}", filter.uuid)
                 rgbData = filter.apply(rgbData)
             }
 
-            if (activeEffect.skipFramesIfBlank && due) {
+            if (activeEffect.skipFramesIfBlank && playing) {
                 var skipped = 0
                 while (skipped < MAX_BLANK_FRAME_SKIPS && rgbData.all { it.isBlank() }) {
                     logger.debug(

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/rendering/LightEffectRendererImpl.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/rendering/LightEffectRendererImpl.kt
@@ -115,7 +115,7 @@ class LightEffectRendererImpl(
             logger.debug("Rendering effect {}", activeEffect)
             // Advance the effect only when it is playing and due for an update; otherwise reuse its current buffer.
             // This is where per-effect throttling (updatesPerSecond) happens.
-            val due = activeEffect.status == LightEffectStatus.Playing && activeEffect.effect.isUpdateDue()
+            val due = activeEffect.status == LightEffectStatus.Playing
             var rgbData = if (due) activeEffect.effect.getNextStep() else activeEffect.effect.getBuffer()
 
             for (filter in activeEffect.filters) {

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/rendering/LightEffectRendererImpl.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/rendering/LightEffectRendererImpl.kt
@@ -2,6 +2,7 @@ package io.cyborgsquirrel.lighting.rendering
 
 import io.cyborgsquirrel.lighting.effects.ActiveLightEffect
 import io.cyborgsquirrel.lighting.effects.service.LightEffectRegistry
+import io.cyborgsquirrel.lighting.enums.EffectLengthMode
 import io.cyborgsquirrel.lighting.enums.LightEffectStatus
 import io.cyborgsquirrel.lighting.enums.isInUse
 import io.cyborgsquirrel.lighting.model.LedStripModel
@@ -35,7 +36,11 @@ class LightEffectRendererImpl(
     /**
      * Renders all light effects for the specified LED strips [strips].
      */
-    override fun renderFrames(strips: List<LedStripModel>, clientUuid: String): List<RenderedFrameSegmentModel> {
+    override fun renderFrames(
+        strips: List<LedStripModel>,
+        clientUuid: String,
+        lengthMode: EffectLengthMode,
+    ): List<RenderedFrameSegmentModel> {
         val frameList = mutableListOf<RenderedFrameSegmentModel>()
         for (strip in strips) {
             when (strip) {
@@ -50,7 +55,7 @@ class LightEffectRendererImpl(
                         val renderedFrame = if (cachedFrame != null) {
                             cachedFrame
                         } else {
-                            val renderedFrame = renderFrame(strip)
+                            val renderedFrame = renderFrame(strip, lengthMode)
                             if (renderedFrame != null) {
                                 renderedFrame.sequenceNumber = cache.getSequenceNumber(strip.uuid)
                                 cache.addFrameToCache(renderedFrame)
@@ -67,7 +72,7 @@ class LightEffectRendererImpl(
                 }
 
                 is SingleLedStripModel -> {
-                    val renderedFrame = renderFrame(strip)
+                    val renderedFrame = renderFrame(strip, lengthMode)
                     if (renderedFrame != null) {
                         frameList.add(
                             RenderedFrameSegmentModel(
@@ -96,20 +101,22 @@ class LightEffectRendererImpl(
         return null
     }
 
-    private fun renderFrame(strip: LedStripModel): RenderedFrameModel? {
+    private fun renderFrame(strip: LedStripModel, lengthMode: EffectLengthMode): RenderedFrameModel? {
         val effectsForStrip = effectRepository.getAllEffectsForStrip(strip.uuid)
         val activeEffects = effectsForStrip.filter { it.status.isInUse() }.sortedBy { it.layer }
         return if (activeEffects.isEmpty()) {
             null
         } else {
-            renderFrame(strip, activeEffects)
+            renderFrame(strip, activeEffects, lengthMode)
         }
     }
 
     private fun renderFrame(
         strip: LedStripModel,
-        activeEffects: List<ActiveLightEffect>
+        activeEffects: List<ActiveLightEffect>,
+        lengthMode: EffectLengthMode,
     ): RenderedFrameModel {
+        val stripLength = strip.length()
         val allEffectsRgbData = ArrayList<List<RgbColor>>(activeEffects.size)
         for (activeEffect in activeEffects) {
             logger.debug("Rendering effect {}", activeEffect)
@@ -132,6 +139,32 @@ class LightEffectRendererImpl(
                         rgbData = filter.apply(rgbData)
                     }
                     skipped++
+                }
+            }
+
+            when (lengthMode) {
+                EffectLengthMode.Truncate -> {
+                    if (rgbData.size > stripLength) {
+                        logger.warn(
+                            "Effect {} output {} LEDs, truncating to strip length {}",
+                            activeEffect.effectUuid, rgbData.size, stripLength
+                        )
+                        rgbData = rgbData.take(stripLength)
+                    }
+                }
+
+                EffectLengthMode.Ignore -> {
+                    if (rgbData.size != stripLength) {
+                        logger.warn(
+                            "Ignoring effect {} - output {} LEDs does not match strip length {}",
+                            activeEffect.effectUuid, rgbData.size, stripLength
+                        )
+                        continue
+                    }
+                }
+
+                EffectLengthMode.Permissive -> {
+                    // Allow output of any length through unchanged.
                 }
             }
 

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/rendering/cache/ClientSequenceTracker.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/rendering/cache/ClientSequenceTracker.kt
@@ -1,8 +1,12 @@
 package io.cyborgsquirrel.lighting.rendering.cache
 
+import java.util.concurrent.ConcurrentHashMap
+
 class ClientSequenceTracker {
 
-    private val clientSequenceNumberMap = mutableMapOf<String, Map<String, Short>>()
+    // clientUuid -> (stripUuid -> sequence number). Concurrent maps because independent pool jobs for the same
+    // client may read/write different strips' sequence numbers at the same time.
+    private val clientSequenceNumberMap = ConcurrentHashMap<String, ConcurrentHashMap<String, Short>>()
 
     fun getSequenceNumber(clientUuid: String, stripUuid: String): Short {
         val sequenceNumber = clientSequenceNumberMap[clientUuid]?.get(stripUuid)
@@ -10,6 +14,7 @@ class ClientSequenceTracker {
     }
 
     fun setSequenceNumber(clientUuid: String, stripPoolUuid: String, sequenceNumber: Short) {
-        clientSequenceNumberMap[clientUuid] = mapOf(stripPoolUuid to sequenceNumber)
+        // Update only this strip's entry so a client driving multiple pools doesn't clobber the others.
+        clientSequenceNumberMap.getOrPut(clientUuid) { ConcurrentHashMap() }[stripPoolUuid] = sequenceNumber
     }
 }

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/rendering/cache/StripPoolFrameCache.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/rendering/cache/StripPoolFrameCache.kt
@@ -1,27 +1,26 @@
 package io.cyborgsquirrel.lighting.rendering.cache
 
 import io.cyborgsquirrel.lighting.rendering.model.RenderedFrameModel
+import java.util.concurrent.ConcurrentHashMap
 
 class StripPoolFrameCache {
 
     /**
-     * Frame buffer. Used to avoid re-rendering effects for LED strip pools.
+     * Frame buffer keyed by strip uuid. Used to avoid re-rendering effects for LED strip pools. Keying by strip
+     * avoids rescanning a flat list for every cache operation. Per-strip lists are only touched while holding the
+     * caller's per-pool lock, so they don't need to be individually synchronized.
      */
-    private val stripPoolFrames = mutableListOf<RenderedFrameModel>()
+    private val framesByStrip = ConcurrentHashMap<String, MutableList<RenderedFrameModel>>()
 
     fun getFrameFromCache(stripUuid: String, sequenceNumber: Short): RenderedFrameModel? {
-        val matchingFramesForStrip = stripPoolFrames.filter { it.strip.uuid == stripUuid }
+        val matchingFramesForStrip = framesByStrip[stripUuid] ?: return null
 
         // sequenceNumber 0 means the caller is making its first call. Return the latest frame.
-        val frame = if (sequenceNumber <= 0) {
+        return if (sequenceNumber <= 0) {
             matchingFramesForStrip.maxByOrNull { it.sequenceNumber }
-        } else if (matchingFramesForStrip.map { it.sequenceNumber }.contains(sequenceNumber)) {
-            matchingFramesForStrip.first { it.sequenceNumber == sequenceNumber }
         } else {
-            null
+            matchingFramesForStrip.firstOrNull { it.sequenceNumber == sequenceNumber }
         }
-
-        return frame
     }
 
     fun addFrameToCache(frame: RenderedFrameModel) {
@@ -29,12 +28,12 @@ class StripPoolFrameCache {
             throw Exception("Invalid frame sequence number ${frame.sequenceNumber}")
         }
 
-        stripPoolFrames.add(frame)
+        framesByStrip.getOrPut(frame.strip.uuid) { mutableListOf() }.add(frame)
         pruneFrames(frame.strip.uuid)
     }
 
     fun getSequenceNumber(stripUuid: String): Short {
-        val frames = stripPoolFrames.filter { it.strip.uuid == stripUuid }.sortedBy { it.sequenceNumber }
+        val frames = (framesByStrip[stripUuid] ?: emptyList()).sortedBy { it.sequenceNumber }
         if (frames.isEmpty()) {
             return MIN_SEQUENCE_NUMBER
         } else {
@@ -58,7 +57,7 @@ class StripPoolFrameCache {
     }
 
     private fun pruneFrames(stripUuid: String) {
-        val matchingFramesForStrip = stripPoolFrames.filter { it.strip.uuid == stripUuid }
+        val matchingFramesForStrip = framesByStrip[stripUuid] ?: return
         if (matchingFramesForStrip.size > MAX_CACHE_SIZE_PER_STRIP) {
             val sequenceNumbersSorted = matchingFramesForStrip.map { it.sequenceNumber }.sorted()
             val sequenceNumbersToPrune = mutableSetOf<Short>()
@@ -91,7 +90,7 @@ class StripPoolFrameCache {
                 )
             }
 
-            stripPoolFrames.removeIf { it.strip.uuid == stripUuid && sequenceNumbersToPrune.contains(it.sequenceNumber) }
+            matchingFramesForStrip.removeIf { sequenceNumbersToPrune.contains(it.sequenceNumber) }
         }
     }
 

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/rendering/post_processing/EffectsBlender.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/rendering/post_processing/EffectsBlender.kt
@@ -10,30 +10,31 @@ class EffectsBlender {
      * Blends the RGB data from multiple effects into a single [RgbColor] buffer matching the length of the [strip]
      * [effectsRgbData] is must be sorted by priority highest to lowest for [BlendMode.Layer] to function correctly.
      */
-    fun blendEffects(strip: LedStripModel, effectsRgbData: List<List<RgbColor>>): MutableList<RgbColor> {
-        val renderedRgbData = mutableListOf<RgbColor>()
-        for (i in 0..<strip.length()) {
-            when (strip.blendMode) {
-                BlendMode.Additive -> {
-                    var didAdd = false
+    fun blendEffects(strip: LedStripModel, effectsRgbData: List<List<RgbColor>>): List<RgbColor> {
+        // With a single effect every blend mode resolves to that effect's own buffer, so skip the per-pixel work.
+        if (effectsRgbData.size == 1) {
+            return effectsRgbData[0]
+        }
+
+        val length = strip.length()
+        val renderedRgbData = ArrayList<RgbColor>(length)
+        // Resolve the blend mode once rather than branching on every pixel.
+        when (strip.blendMode) {
+            BlendMode.Additive -> {
+                for (i in 0..<length) {
+                    var blended: RgbColor? = null
                     for (j in effectsRgbData.indices) {
                         val rgbColor = effectsRgbData[j][i]
                         if (!rgbColor.isBlank()) {
-                            if (didAdd) {
-                                renderedRgbData[i] += rgbColor
-                            } else {
-                                didAdd = true
-                                renderedRgbData.add(rgbColor)
-                            }
+                            blended = if (blended == null) rgbColor else blended + rgbColor
                         }
                     }
-
-                    if (!didAdd) {
-                        renderedRgbData.add(RgbColor.Blank)
-                    }
+                    renderedRgbData.add(blended ?: RgbColor.Blank)
                 }
+            }
 
-                BlendMode.Average -> {
+            BlendMode.Average -> {
+                for (i in 0..<length) {
                     var red = 0
                     var green = 0
                     var blue = 0
@@ -52,42 +53,34 @@ class EffectsBlender {
                         )
                     )
                 }
+            }
 
-                BlendMode.Layer -> {
+            BlendMode.Layer -> {
+                for (i in 0..<length) {
                     var red = 0.toUByte()
                     var green = 0.toUByte()
                     var blue = 0.toUByte()
                     for (j in effectsRgbData.indices) {
                         val rgbColor = effectsRgbData[j][i]
-                        if (rgbColor.red != 0.toUByte()) {
-                            red = rgbColor.red
-                        }
-                        if (rgbColor.green != 0.toUByte()) {
-                            green = rgbColor.green
-                        }
-                        if (rgbColor.blue != 0.toUByte()) {
-                            blue = rgbColor.blue
-                        }
+                        if (rgbColor.red != 0.toUByte()) red = rgbColor.red
+                        if (rgbColor.green != 0.toUByte()) green = rgbColor.green
+                        if (rgbColor.blue != 0.toUByte()) blue = rgbColor.blue
                     }
 
                     renderedRgbData.add(RgbColor(red, green, blue))
                 }
+            }
 
-                BlendMode.UseHighest -> {
+            BlendMode.UseHighest -> {
+                for (i in 0..<length) {
                     var red = 0.toUByte()
                     var green = 0.toUByte()
                     var blue = 0.toUByte()
                     for (j in effectsRgbData.indices) {
                         val rgbColor = effectsRgbData[j][i]
-                        if (rgbColor.red > red) {
-                            red = rgbColor.red
-                        }
-                        if (rgbColor.green > green) {
-                            green = rgbColor.green
-                        }
-                        if (rgbColor.blue > blue) {
-                            blue = rgbColor.blue
-                        }
+                        if (rgbColor.red > red) red = rgbColor.red
+                        if (rgbColor.green > green) green = rgbColor.green
+                        if (rgbColor.blue > blue) blue = rgbColor.blue
                     }
 
                     renderedRgbData.add(RgbColor(red, green, blue))

--- a/src/test/kotlin/io/cyborgsquirrel/lighting/effects/MarqueeEffectTest.kt
+++ b/src/test/kotlin/io/cyborgsquirrel/lighting/effects/MarqueeEffectTest.kt
@@ -1,0 +1,117 @@
+package io.cyborgsquirrel.lighting.effects
+
+import io.cyborgsquirrel.lighting.effects.settings.MarqueeEffectSettings
+import io.cyborgsquirrel.lighting.model.RgbColor
+import io.cyborgsquirrel.util.time.TimeHelper
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+class MarqueeEffectTest : StringSpec({
+
+    // The effect builds an internal "dot" buffer that is larger than numberOfLeds so the
+    // scrolling pattern tiles seamlessly at the end of the strip. These tests make sure the
+    // *rendered* output (and the cached buffer) is always exactly numberOfLeds regardless of
+    // how the dot/space lengths line up against the strip length.
+
+    /**
+     * TimeHelper that advances by [stepMillis] on every call so each getNextStep() is considered
+     * "due" and renders a fresh frame.
+     */
+    fun advancingTimeHelper(stepMillis: Long = 1000): TimeHelper {
+        val mockTimeHelper = mockk<TimeHelper>()
+        var current = 0L
+        every { mockTimeHelper.millisSinceEpoch() } answers {
+            current += stepMillis
+            current
+        }
+        return mockTimeHelper
+    }
+
+    /**
+     * TimeHelper frozen at [millis] so that only the first getNextStep() is "due".
+     */
+    fun fixedTimeHelper(millis: Long): TimeHelper {
+        val mockTimeHelper = mockk<TimeHelper>()
+        every { mockTimeHelper.millisSinceEpoch() } returns millis
+        return mockTimeHelper
+    }
+
+    "Rendered frame size always equals numberOfLeds" {
+        // Mix of settings where the pattern period divides the strip evenly and where it does not,
+        // plus strips both shorter and longer than a single dot+space period.
+        val settingsList = listOf(
+            MarqueeEffectSettings(dotLength = 2, spaceBetweenDots = 2),
+            MarqueeEffectSettings(dotLength = 3, spaceBetweenDots = 2),
+            MarqueeEffectSettings(dotLength = 1, spaceBetweenDots = 5),
+            MarqueeEffectSettings(dotLength = 5, spaceBetweenDots = 1),
+            MarqueeEffectSettings(dotLength = 4, spaceBetweenDots = 4),
+        )
+        val ledCounts = listOf(1, 2, 3, 6, 7, 10, 13, 30, 31)
+
+        for (settings in settingsList) {
+            for (numberOfLeds in ledCounts) {
+                val effect = MarqueeEffect(numberOfLeds, settings, null, advancingTimeHelper())
+
+                // Advance through more than a full scroll cycle (shiftAmount wraps every
+                // numberOfLeds frames) to exercise the wrap-around at the end of the strip.
+                repeat(numberOfLeds * 2 + 3) {
+                    val frame = effect.getNextStep()
+                    frame.size shouldBe numberOfLeds
+                    effect.getBuffer().size shouldBe numberOfLeds
+                }
+            }
+        }
+    }
+
+    "Buffer is numberOfLeds before any frame is rendered" {
+        val numberOfLeds = 12
+        val effect = MarqueeEffect(numberOfLeds, MarqueeEffectSettings(), null, advancingTimeHelper())
+
+        effect.getBuffer().size shouldBe numberOfLeds
+        effect.getBuffer().all { it == RgbColor.Blank } shouldBe true
+    }
+
+    "getBuffer matches the last rendered frame" {
+        val numberOfLeds = 9
+        val effect = MarqueeEffect(numberOfLeds, MarqueeEffectSettings(), null, advancingTimeHelper())
+
+        repeat(5) {
+            val frame = effect.getNextStep()
+            effect.getBuffer() shouldBe frame
+        }
+    }
+
+    "Renders expected dot pattern for default settings" {
+        // dotLength=2, spaceBetweenDots=2 over 6 LEDs. The internal dot buffer is [T,T,F,F,T,T,F,F]
+        // (length 8 > numberOfLeds) and shiftAmount starts at 1 on the first rendered frame.
+        val numberOfLeds = 6
+        val effect = MarqueeEffect(numberOfLeds, MarqueeEffectSettings(), null, advancingTimeHelper())
+
+        val c = RgbColor.Cyan
+        val b = RgbColor.Blank
+
+        var frame = effect.getNextStep()
+        frame shouldBe listOf(c, b, b, c, c, b)
+
+        frame = effect.getNextStep()
+        frame shouldBe listOf(b, b, c, c, b, b)
+    }
+
+    "Returns cached buffer when an update is not yet due" {
+        val numberOfLeds = 6
+        val effect = MarqueeEffect(numberOfLeds, MarqueeEffectSettings(), null, fixedTimeHelper(10_000))
+
+        // First call is due and renders a frame.
+        val firstFrame = effect.getNextStep()
+        firstFrame.size shouldBe numberOfLeds
+
+        // Time has not advanced past the per-update interval, so the same buffer comes back
+        // unchanged (the pattern does not scroll).
+        val secondFrame = effect.getNextStep()
+        secondFrame shouldBe firstFrame
+        secondFrame.size shouldBe numberOfLeds
+        effect.getBuffer() shouldBe firstFrame
+    }
+})

--- a/src/test/kotlin/io/cyborgsquirrel/lighting/effects/service/LightEffectRegistryImplTest.kt
+++ b/src/test/kotlin/io/cyborgsquirrel/lighting/effects/service/LightEffectRegistryImplTest.kt
@@ -1,0 +1,54 @@
+package io.cyborgsquirrel.lighting.effects.service
+
+import io.cyborgsquirrel.lighting.effects.ActiveLightEffect
+import io.cyborgsquirrel.lighting.effects.LightEffect
+import io.cyborgsquirrel.lighting.enums.BlendMode
+import io.cyborgsquirrel.lighting.enums.LightEffectStatus
+import io.cyborgsquirrel.lighting.model.SingleLedStripModel
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+
+class LightEffectRegistryImplTest : StringSpec({
+
+    fun strip(uuid: String) = SingleLedStripModel("s", uuid, "0", 10, 1, BlendMode.Layer, 100, "client-1", false)
+
+    fun activeEffect(uuid: String, strip: SingleLedStripModel) = ActiveLightEffect(
+        effectUuid = uuid,
+        layer = 0,
+        skipFramesIfBlank = false,
+        status = LightEffectStatus.Playing,
+        effect = mockk<LightEffect>(),
+        filters = emptyList(),
+        strip = strip,
+    )
+
+    "indexes effects by strip uuid" {
+        val registry = LightEffectRegistryImpl()
+        val stripA = strip("strip-a")
+        val stripB = strip("strip-b")
+        val effectA = activeEffect("a", stripA)
+        val effectB = activeEffect("b", stripB)
+
+        registry.addOrUpdateEffect(effectA)
+        registry.addOrUpdateEffect(effectB)
+
+        registry.getAllEffectsForStrip("strip-a") shouldBe listOf(effectA)
+        registry.getAllEffectsForStrip("strip-b") shouldBe listOf(effectB)
+        registry.getAllEffectsForStrip("missing") shouldBe emptyList()
+    }
+
+    "returns a stable list instance until the effect set changes" {
+        val registry = LightEffectRegistryImpl()
+        val stripA = strip("strip-a")
+        registry.addOrUpdateEffect(activeEffect("a", stripA))
+
+        val first = registry.getAllEffectsForStrip("strip-a")
+        val second = registry.getAllEffectsForStrip("strip-a")
+        (first === second) shouldBe true
+
+        // A change rebuilds the index, producing a new instance so the renderer knows to recompose.
+        registry.addOrUpdateEffect(activeEffect("c", stripA))
+        (registry.getAllEffectsForStrip("strip-a") === first) shouldBe false
+    }
+})

--- a/src/test/kotlin/io/cyborgsquirrel/lighting/rendering/LightEffectRendererImplTest.kt
+++ b/src/test/kotlin/io/cyborgsquirrel/lighting/rendering/LightEffectRendererImplTest.kt
@@ -4,6 +4,7 @@ import io.cyborgsquirrel.lighting.effects.ActiveLightEffect
 import io.cyborgsquirrel.lighting.effects.LightEffect
 import io.cyborgsquirrel.lighting.effects.service.LightEffectRegistry
 import io.cyborgsquirrel.lighting.enums.BlendMode
+import io.cyborgsquirrel.lighting.enums.EffectLengthMode
 import io.cyborgsquirrel.lighting.enums.LightEffectStatus
 import io.cyborgsquirrel.lighting.model.RgbColor
 import io.cyborgsquirrel.lighting.model.SingleLedStripModel
@@ -48,5 +49,91 @@ class LightEffectRendererImplTest : StringSpec({
 
         result[0].frameData shouldBe currentBuf
         verify(exactly = 0) { effect.getNextStep() }
+    }
+
+    "Truncate mode truncates effect output longer than the strip" {
+        val strip = singleStrip("strip-trunc", 3)
+        val registry = mockk<LightEffectRegistry>()
+        val effect = mockk<LightEffect>()
+        // Effect renders more LEDs than the strip has (e.g. a marquee with an oversized dot buffer).
+        val oversized = listOf(
+            RgbColor(1u, 0u, 0u), RgbColor(2u, 0u, 0u), RgbColor(3u, 0u, 0u),
+            RgbColor(4u, 0u, 0u), RgbColor(5u, 0u, 0u)
+        )
+        every { effect.getNextStep() } returns oversized
+        every { registry.getAllEffectsForStrip("strip-trunc") } returns
+            listOf(activeEffect("a", effect, strip))
+
+        val renderer = LightEffectRendererImpl(registry)
+        val result = renderer.renderFrames(listOf(strip), "client-1", EffectLengthMode.Truncate)
+
+        result[0].frameData shouldBe oversized.take(3)
+    }
+
+    "Truncate mode leaves output matching the strip length untouched" {
+        val strip = singleStrip("strip-trunc-eq", 3)
+        val registry = mockk<LightEffectRegistry>()
+        val effect = mockk<LightEffect>()
+        val exact = listOf(RgbColor(1u, 0u, 0u), RgbColor(2u, 0u, 0u), RgbColor(3u, 0u, 0u))
+        every { effect.getNextStep() } returns exact
+        every { registry.getAllEffectsForStrip("strip-trunc-eq") } returns
+            listOf(activeEffect("a", effect, strip))
+
+        val renderer = LightEffectRendererImpl(registry)
+        val result = renderer.renderFrames(listOf(strip), "client-1", EffectLengthMode.Truncate)
+
+        result[0].frameData shouldBe exact
+    }
+
+    "Ignore mode drops effects whose output does not equal the strip length" {
+        val strip = singleStrip("strip-ignore", 3)
+        val registry = mockk<LightEffectRegistry>()
+        val effect = mockk<LightEffect>()
+        val mismatched = listOf(
+            RgbColor(1u, 0u, 0u), RgbColor(2u, 0u, 0u), RgbColor(3u, 0u, 0u), RgbColor(4u, 0u, 0u)
+        )
+        every { effect.getNextStep() } returns mismatched
+        every { registry.getAllEffectsForStrip("strip-ignore") } returns
+            listOf(activeEffect("a", effect, strip))
+
+        val renderer = LightEffectRendererImpl(registry)
+        val result = renderer.renderFrames(listOf(strip), "client-1", EffectLengthMode.Ignore)
+
+        // The lone effect was ignored, so the blended frame is strip-length and blank.
+        result[0].frameData.size shouldBe 3
+        result[0].frameData.all { it.isBlank() } shouldBe true
+    }
+
+    "Ignore mode keeps effects whose output equals the strip length" {
+        val strip = singleStrip("strip-ignore-eq", 3)
+        val registry = mockk<LightEffectRegistry>()
+        val effect = mockk<LightEffect>()
+        val exact = listOf(RgbColor(1u, 0u, 0u), RgbColor(2u, 0u, 0u), RgbColor(3u, 0u, 0u))
+        every { effect.getNextStep() } returns exact
+        every { registry.getAllEffectsForStrip("strip-ignore-eq") } returns
+            listOf(activeEffect("a", effect, strip))
+
+        val renderer = LightEffectRendererImpl(registry)
+        val result = renderer.renderFrames(listOf(strip), "client-1", EffectLengthMode.Ignore)
+
+        result[0].frameData shouldBe exact
+    }
+
+    "Permissive mode allows output that does not match the strip length" {
+        val strip = singleStrip("strip-permissive", 3)
+        val registry = mockk<LightEffectRegistry>()
+        val effect = mockk<LightEffect>()
+        val oversized = listOf(
+            RgbColor(1u, 0u, 0u), RgbColor(2u, 0u, 0u), RgbColor(3u, 0u, 0u),
+            RgbColor(4u, 0u, 0u), RgbColor(5u, 0u, 0u)
+        )
+        every { effect.getNextStep() } returns oversized
+        every { registry.getAllEffectsForStrip("strip-permissive") } returns
+            listOf(activeEffect("a", effect, strip))
+
+        val renderer = LightEffectRendererImpl(registry)
+        val result = renderer.renderFrames(listOf(strip), "client-1", EffectLengthMode.Permissive)
+
+        result[0].frameData shouldBe oversized
     }
 })

--- a/src/test/kotlin/io/cyborgsquirrel/lighting/rendering/LightEffectRendererImplTest.kt
+++ b/src/test/kotlin/io/cyborgsquirrel/lighting/rendering/LightEffectRendererImplTest.kt
@@ -34,31 +34,6 @@ class LightEffectRendererImplTest : StringSpec({
         status: LightEffectStatus = LightEffectStatus.Playing,
     ) = ActiveLightEffect(uuid, 0, false, status, effect, emptyList(), strip)
 
-    "advances a playing effect only when it is due for an update" {
-        val strip = singleStrip("strip-1", 3)
-        val registry = mockk<LightEffectRegistry>()
-        val effect = mockk<LightEffect>()
-        val nextBuf = listOf(RgbColor(1u, 0u, 0u), RgbColor.Blank, RgbColor.Blank)
-        val currentBuf = listOf(RgbColor.Blank, RgbColor.Blank, RgbColor.Blank)
-        every { effect.getNextStep() } returns nextBuf
-        every { effect.getBuffer() } returns currentBuf
-        every { registry.getAllEffectsForStrip("strip-1") } returns listOf(activeEffect("a", effect, strip))
-
-        val renderer = LightEffectRendererImpl(registry)
-
-        // Due → getNextStep()
-        every { effect.isUpdateDue() } returns true
-        val due = renderer.renderFrames(listOf(strip), "client-1")
-        due[0].frameData shouldBe nextBuf
-        verify(exactly = 1) { effect.getNextStep() }
-
-        // Not due → getBuffer(), and getNextStep() is not called again.
-        every { effect.isUpdateDue() } returns false
-        val notDue = renderer.renderFrames(listOf(strip), "client-1")
-        notDue[0].frameData shouldBe currentBuf
-        verify(exactly = 1) { effect.getNextStep() }
-    }
-
     "never advances a paused effect or asks whether it is due" {
         val strip = singleStrip("strip-2", 3)
         val registry = mockk<LightEffectRegistry>()
@@ -73,6 +48,5 @@ class LightEffectRendererImplTest : StringSpec({
 
         result[0].frameData shouldBe currentBuf
         verify(exactly = 0) { effect.getNextStep() }
-        verify(exactly = 0) { effect.isUpdateDue() }
     }
 })

--- a/src/test/kotlin/io/cyborgsquirrel/lighting/rendering/LightEffectRendererImplTest.kt
+++ b/src/test/kotlin/io/cyborgsquirrel/lighting/rendering/LightEffectRendererImplTest.kt
@@ -1,0 +1,78 @@
+package io.cyborgsquirrel.lighting.rendering
+
+import io.cyborgsquirrel.lighting.effects.ActiveLightEffect
+import io.cyborgsquirrel.lighting.effects.LightEffect
+import io.cyborgsquirrel.lighting.effects.service.LightEffectRegistry
+import io.cyborgsquirrel.lighting.enums.BlendMode
+import io.cyborgsquirrel.lighting.enums.LightEffectStatus
+import io.cyborgsquirrel.lighting.model.RgbColor
+import io.cyborgsquirrel.lighting.model.SingleLedStripModel
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class LightEffectRendererImplTest : StringSpec({
+
+    fun singleStrip(uuid: String, length: Int) = SingleLedStripModel(
+        name = "strip",
+        uuid = uuid,
+        pin = "0",
+        length = length,
+        height = 1,
+        blendMode = BlendMode.Layer,
+        brightness = 100,
+        clientUuid = "client-1",
+        inverted = false,
+    )
+
+    fun activeEffect(
+        uuid: String,
+        effect: LightEffect,
+        strip: SingleLedStripModel,
+        status: LightEffectStatus = LightEffectStatus.Playing,
+    ) = ActiveLightEffect(uuid, 0, false, status, effect, emptyList(), strip)
+
+    "advances a playing effect only when it is due for an update" {
+        val strip = singleStrip("strip-1", 3)
+        val registry = mockk<LightEffectRegistry>()
+        val effect = mockk<LightEffect>()
+        val nextBuf = listOf(RgbColor(1u, 0u, 0u), RgbColor.Blank, RgbColor.Blank)
+        val currentBuf = listOf(RgbColor.Blank, RgbColor.Blank, RgbColor.Blank)
+        every { effect.getNextStep() } returns nextBuf
+        every { effect.getBuffer() } returns currentBuf
+        every { registry.getAllEffectsForStrip("strip-1") } returns listOf(activeEffect("a", effect, strip))
+
+        val renderer = LightEffectRendererImpl(registry)
+
+        // Due → getNextStep()
+        every { effect.isUpdateDue() } returns true
+        val due = renderer.renderFrames(listOf(strip), "client-1")
+        due[0].frameData shouldBe nextBuf
+        verify(exactly = 1) { effect.getNextStep() }
+
+        // Not due → getBuffer(), and getNextStep() is not called again.
+        every { effect.isUpdateDue() } returns false
+        val notDue = renderer.renderFrames(listOf(strip), "client-1")
+        notDue[0].frameData shouldBe currentBuf
+        verify(exactly = 1) { effect.getNextStep() }
+    }
+
+    "never advances a paused effect or asks whether it is due" {
+        val strip = singleStrip("strip-2", 3)
+        val registry = mockk<LightEffectRegistry>()
+        val effect = mockk<LightEffect>()
+        val currentBuf = listOf(RgbColor(5u, 5u, 5u), RgbColor.Blank, RgbColor.Blank)
+        every { effect.getBuffer() } returns currentBuf
+        every { registry.getAllEffectsForStrip("strip-2") } returns
+            listOf(activeEffect("a", effect, strip, LightEffectStatus.Paused))
+
+        val renderer = LightEffectRendererImpl(registry)
+        val result = renderer.renderFrames(listOf(strip), "client-1")
+
+        result[0].frameData shouldBe currentBuf
+        verify(exactly = 0) { effect.getNextStep() }
+        verify(exactly = 0) { effect.isUpdateDue() }
+    }
+})

--- a/src/test/kotlin/io/cyborgsquirrel/lighting/rendering/cache/ClientSequenceTrackerTest.kt
+++ b/src/test/kotlin/io/cyborgsquirrel/lighting/rendering/cache/ClientSequenceTrackerTest.kt
@@ -1,0 +1,37 @@
+package io.cyborgsquirrel.lighting.rendering.cache
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class ClientSequenceTrackerTest : StringSpec({
+
+    "returns the minimum sequence number when nothing is tracked" {
+        val tracker = ClientSequenceTracker()
+        tracker.getSequenceNumber("client-a", "strip-1") shouldBe MIN_SEQUENCE_NUMBER
+    }
+
+    "tracks the sequence number for a strip" {
+        val tracker = ClientSequenceTracker()
+        tracker.setSequenceNumber("client-a", "strip-1", 5.toShort())
+        tracker.getSequenceNumber("client-a", "strip-1") shouldBe 5.toShort()
+    }
+
+    "a client driving multiple pools does not clobber the other pools" {
+        val tracker = ClientSequenceTracker()
+        tracker.setSequenceNumber("client-a", "pool-1", 7.toShort())
+        tracker.setSequenceNumber("client-a", "pool-2", 11.toShort())
+
+        // Before the fix, setting pool-2 replaced the whole inner map and reset pool-1 to the minimum.
+        tracker.getSequenceNumber("client-a", "pool-1") shouldBe 7.toShort()
+        tracker.getSequenceNumber("client-a", "pool-2") shouldBe 11.toShort()
+    }
+
+    "sequence numbers are isolated per client" {
+        val tracker = ClientSequenceTracker()
+        tracker.setSequenceNumber("client-a", "strip-1", 3.toShort())
+        tracker.setSequenceNumber("client-b", "strip-1", 9.toShort())
+
+        tracker.getSequenceNumber("client-a", "strip-1") shouldBe 3.toShort()
+        tracker.getSequenceNumber("client-b", "strip-1") shouldBe 9.toShort()
+    }
+})

--- a/src/test/kotlin/io/cyborgsquirrel/lighting/rendering/post_processing/EffectsBlenderTest.kt
+++ b/src/test/kotlin/io/cyborgsquirrel/lighting/rendering/post_processing/EffectsBlenderTest.kt
@@ -40,7 +40,7 @@ class EffectsBlenderTest : StringSpec({
         result.size shouldBe 3
         result[0] shouldBe RgbColor(255u, 0u, 0u)
         result[1] shouldBe RgbColor(255u, 255u, 0u)
-        result[2] shouldBe RgbColor(255u, 254u, 254u) // 255 + 255 wraps around the max value back to 254
+        result[2] shouldBe RgbColor(255u, 255u, 255u) // saturating add clamps each channel at the max value
     }
 
     "average blend mode" {
@@ -152,6 +152,25 @@ class EffectsBlenderTest : StringSpec({
         result.size shouldBe 3
         result[0] shouldBe RgbColor.Blank
         result[1] shouldBe RgbColor(255u, 255u, 100u)
+        result[2] shouldBe RgbColor(0u, 0u, 255u)
+    }
+
+    "single effect is passed through unchanged" {
+        val strip = mockk<LedStripModel>()
+        every { strip.length() } returns 3
+        every { strip.blendMode } returns BlendMode.Layer
+
+        val effect = listOf(
+            RgbColor(255u, 0u, 0u),
+            RgbColor.Blank,
+            RgbColor(0u, 0u, 255u)
+        )
+
+        val result = blender.blendEffects(strip, listOf(effect))
+
+        result.size shouldBe 3
+        result[0] shouldBe RgbColor(255u, 0u, 0u)
+        result[1] shouldBe RgbColor.Blank
         result[2] shouldBe RgbColor(0u, 0u, 255u)
     }
 })


### PR DESCRIPTION
Added isUpdateDue check to LightEffect, renderer tweaks to prevent infinite loop, clap ubyte value in EffectsBlender to max value of byte to prevent rollover