### PR TITLE
Query optimizations, create client address check

### DIFF
--- a/src/main/kotlin/io/cyborgsquirrel/clients/repository/LedStripClientRepository.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/clients/repository/LedStripClientRepository.kt
@@ -10,8 +10,9 @@ interface LedStripClientRepository : CrudRepository<LedStripClientEntity, Long> 
     fun findByUuid(uuid: String): Optional<LedStripClientEntity>
 
     @Join(value = "strips", type = Join.Type.LEFT_FETCH)
-    fun findByAddress(name: String): Optional<LedStripClientEntity>
-
-    @Join(value = "strips", type = Join.Type.LEFT_FETCH)
     fun queryAll(): List<LedStripClientEntity>
+
+    fun getByUuid(uuid: String): Optional<LedStripClientEntity>
+
+    fun existsByAddress(address: String): Boolean
 }

--- a/src/main/kotlin/io/cyborgsquirrel/clients/services/LedClientApiService.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/clients/services/LedClientApiService.kt
@@ -27,7 +27,7 @@ class LedClientApiService(
 ) {
 
     fun getAllClients(): GetClientsResponse {
-        val clientEntities = clientRepository.queryAll()
+        val clientEntities = clientRepository.findAll()
         val responseClients = clientEntities.map {
             mapClientEntityToResponse(it)
         }
@@ -35,7 +35,7 @@ class LedClientApiService(
     }
 
     fun getClientWithUuid(uuid: String): GetClientResponse {
-        val clientEntityOptional = clientRepository.findByUuid(uuid)
+        val clientEntityOptional = clientRepository.getByUuid(uuid)
         if (clientEntityOptional.isPresent) {
             val clientEntity = clientEntityOptional.get()
             return mapClientEntityToResponse(clientEntity)
@@ -45,9 +45,8 @@ class LedClientApiService(
     }
 
     fun createClient(request: CreateClientRequest): String {
-        val entityOptional = clientRepository.findByAddress(request.address)
-        return if (entityOptional.isPresent) {
-            entityOptional.get().uuid
+        return if (clientRepository.existsByAddress(request.address)) {
+            throw ClientRequestException("A client with address ${request.address} already exists!")
         } else {
             // Default to RGB if no color order is specified - it is not required for Pi clients
             val colorOrder = request.colorOrder ?: ColorOrder.RGB

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/repository/LightEffectRepository.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/repository/LightEffectRepository.kt
@@ -22,19 +22,18 @@ interface LightEffectRepository : CrudRepository<LightEffectEntity, Long> {
     @Join(value = "pool", type = Join.Type.LEFT_FETCH)
     @Join(value = "palette", type = Join.Type.LEFT_FETCH)
     @Join(value = "effectSettings", type = Join.Type.LEFT_FETCH)
-    @Join(value = "pool.members", type = Join.Type.LEFT_FETCH)
-    @Join(value = "triggers", type = Join.Type.LEFT_FETCH)
-    @Join(value = "filterJunctions", type = Join.Type.LEFT_FETCH)
     fun findByStrip(strip: LedStripEntity): List<LightEffectEntity>
 
     @Join(value = "strip", type = Join.Type.LEFT_FETCH)
     @Join(value = "pool", type = Join.Type.LEFT_FETCH)
     @Join(value = "palette", type = Join.Type.LEFT_FETCH)
     @Join(value = "effectSettings", type = Join.Type.LEFT_FETCH)
-    @Join(value = "pool.members", type = Join.Type.LEFT_FETCH)
-    @Join(value = "triggers", type = Join.Type.LEFT_FETCH)
-    @Join(value = "filterJunctions", type = Join.Type.LEFT_FETCH)
     fun findByPool(pool: LedStripPoolEntity): List<LightEffectEntity>
+
+    // Counts only — no joins, so this never materializes the effect graph just to size it.
+    fun countByStrip(strip: LedStripEntity): Long
+
+    fun countByPool(pool: LedStripPoolEntity): Long
 
     @Join(value = "strip", type = Join.Type.LEFT_FETCH)
     @Join(value = "pool", type = Join.Type.LEFT_FETCH)

--- a/src/main/kotlin/io/cyborgsquirrel/lighting/effects/service/EffectApiService.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/lighting/effects/service/EffectApiService.kt
@@ -98,7 +98,7 @@ open class EffectApiService(
             stripUuid != null -> {
                 val stripEntity = stripRepository.findByUuid(stripUuid)
                     .orElseThrow { ClientRequestException("No strip found with uuid $stripUuid!") }
-                val count = effectRepository.findByStrip(stripEntity).size
+                val count = effectRepository.countByStrip(stripEntity).toInt()
                 val targetLayer = request.layer ?: count
                 validateLayerForInsert(targetLayer, count, "strip ${stripEntity.uuid}")
                 if (targetLayer < count) {
@@ -122,7 +122,7 @@ open class EffectApiService(
             poolUuid != null -> {
                 val poolEntity = poolRepository.findByUuid(poolUuid)
                     .orElseThrow { ClientRequestException("No pool found with uuid $poolUuid!") }
-                val count = effectRepository.findByPool(poolEntity).size
+                val count = effectRepository.countByPool(poolEntity).toInt()
                 val targetLayer = request.layer ?: count
                 validateLayerForInsert(targetLayer, count, "pool ${poolEntity.uuid}")
                 if (targetLayer < count) {
@@ -335,8 +335,8 @@ open class EffectApiService(
         val assigned = owningStrip != null || owningPool != null
         if (updateEffectRequest.layer != null && assigned) {
             val count = when {
-                owningStrip != null -> effectRepository.findByStrip(owningStrip).size
-                owningPool != null -> effectRepository.findByPool(owningPool).size
+                owningStrip != null -> effectRepository.countByStrip(owningStrip).toInt()
+                owningPool != null -> effectRepository.countByPool(owningPool).toInt()
                 else -> 0
             }
             val maxValid = count - 1
@@ -461,8 +461,8 @@ open class EffectApiService(
         val targetLayer = if (unassigned) {
             0
         } else when {
-            newStrip != null -> effectRepository.findByStrip(newStrip).size
-            newPool != null -> effectRepository.findByPool(newPool).size
+            newStrip != null -> effectRepository.countByStrip(newStrip).toInt()
+            newPool != null -> effectRepository.countByPool(newPool).toInt()
             else -> 0
         }
 

--- a/src/main/kotlin/io/cyborgsquirrel/strip_pools/services/StripPoolApiService.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/strip_pools/services/StripPoolApiService.kt
@@ -5,6 +5,7 @@ import io.cyborgsquirrel.clients.status.ClientStatusService
 import io.cyborgsquirrel.event_source.model.StripPoolEvent
 import io.cyborgsquirrel.event_source.model.delta.PoolDelta
 import io.cyborgsquirrel.event_source.service.SseEventEmitter
+import io.cyborgsquirrel.led_strips.entity.LedStripEntity
 import io.cyborgsquirrel.led_strips.entity.LedStripPoolEntity
 import io.cyborgsquirrel.led_strips.entity.PoolMemberLedStripEntity
 import io.cyborgsquirrel.led_strips.repository.LedStripPoolRepository
@@ -31,15 +32,27 @@ class StripPoolApiService(
     private val clientStatusService: ClientStatusService,
 ) {
 
+    /** One batched lookup of every member's strip (with its client) keyed by strip uuid. */
+    private fun fetchStripsByUuid(memberEntities: List<PoolMemberLedStripEntity>): Map<String, LedStripEntity> {
+        val stripUuids = memberEntities.mapNotNull { it.strip?.uuid }.distinct()
+        if (stripUuids.isEmpty()) return emptyMap()
+        return stripRepository.findByUuidIn(stripUuids).associateBy { it.uuid }
+    }
+
     private fun mapPoolEntityToModel(
         poolEntity: LedStripPoolEntity,
         memberEntities: List<PoolMemberLedStripEntity>
+    ): GetStripPoolResponse = mapPoolEntityToModel(poolEntity, memberEntities, fetchStripsByUuid(memberEntities))
+
+    private fun mapPoolEntityToModel(
+        poolEntity: LedStripPoolEntity,
+        memberEntities: List<PoolMemberLedStripEntity>,
+        stripsByUuid: Map<String, LedStripEntity>,
     ): GetStripPoolResponse {
-        val stripEntities = stripRepository.findByUuidIn(memberEntities.map { it.strip!!.uuid })
         val memberResponseModels = mutableListOf<StripPoolMemberResponseModel>()
         var atLeastOnePoolMemberInUse = false
         memberEntities.forEach { me ->
-            val clientEntity = stripEntities.first { se -> se.uuid == me.strip!!.uuid }.client
+            val clientEntity = stripsByUuid.getValue(me.strip!!.uuid).client
             val clientStatus = if (clientEntity == null) null else clientStatusService.getStatusForClient(clientEntity)
                 .getOrNull()?.status
             val inUse = clientStatus == ClientStatus.Active
@@ -79,7 +92,9 @@ class StripPoolApiService(
 
     fun getStripPools(): GetStripPoolsResponse {
         val poolEntities = poolRepository.queryAll()
-        val responseModels = poolEntities.map { mapPoolEntityToModel(it, it.members.toList()) }
+        // Batch every pool's member strips into a single lookup instead of one query per pool.
+        val stripsByUuid = fetchStripsByUuid(poolEntities.flatMap { it.members })
+        val responseModels = poolEntities.map { mapPoolEntityToModel(it, it.members.toList(), stripsByUuid) }
         return GetStripPoolsResponse(responseModels)
     }
 

--- a/src/main/kotlin/io/cyborgsquirrel/strip_pools/services/StripPoolApiService.kt
+++ b/src/main/kotlin/io/cyborgsquirrel/strip_pools/services/StripPoolApiService.kt
@@ -52,7 +52,7 @@ class StripPoolApiService(
         val memberResponseModels = mutableListOf<StripPoolMemberResponseModel>()
         var atLeastOnePoolMemberInUse = false
         memberEntities.forEach { me ->
-            val clientEntity = stripsByUuid.getValue(me.strip!!.uuid).client
+            val clientEntity = me.strip?.let { stripsByUuid[it.uuid] }?.client
             val clientStatus = if (clientEntity == null) null else clientStatusService.getStatusForClient(clientEntity)
                 .getOrNull()?.status
             val inUse = clientStatus == ClientStatus.Active

--- a/src/test/kotlin/io/cyborgsquirrel/clients/services/LedClientApiServiceTest.kt
+++ b/src/test/kotlin/io/cyborgsquirrel/clients/services/LedClientApiServiceTest.kt
@@ -1,36 +1,230 @@
 package io.cyborgsquirrel.clients.services
 
+import io.cyborgsquirrel.clients.enums.ClientStatus
+import io.cyborgsquirrel.clients.enums.ClientType
 import io.cyborgsquirrel.clients.enums.ColorOrder
+import io.cyborgsquirrel.clients.entity.LedStripClientEntity
 import io.cyborgsquirrel.clients.repository.LedStripClientRepository
+import io.cyborgsquirrel.clients.requests.CreateClientRequest
 import io.cyborgsquirrel.clients.requests.UpdateClientRequest
+import io.cyborgsquirrel.clients.responses.GetClientResponse
+import io.cyborgsquirrel.clients.status.ClientStatusInfo
+import io.cyborgsquirrel.clients.status.ClientStatusService
+import io.cyborgsquirrel.event_source.model.LedClientEvent
+import io.cyborgsquirrel.event_source.model.SseEvent
+import io.cyborgsquirrel.event_source.model.delta.ClientDelta
+import io.cyborgsquirrel.event_source.service.SseEventEmitter
 import io.cyborgsquirrel.jobs.streaming.StreamJobManager
 import io.cyborgsquirrel.led_strips.repository.LedStripRepository
 import io.cyborgsquirrel.test_helpers.createLedStripClientEntity
+import io.cyborgsquirrel.test_helpers.saveLedStrip
+import io.cyborgsquirrel.util.exception.ClientRequestException
+import io.cyborgsquirrel.util.exception.ResourceNotFoundException
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.micronaut.test.annotation.MockBean
 import io.micronaut.test.extensions.kotest5.MicronautKotest5Extension.getMock
 import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import reactor.core.Disposable
+import java.util.*
+import java.util.concurrent.CopyOnWriteArrayList
 
 @MicronautTest
 class LedClientApiServiceTest(
     private val ledClientApiService: LedClientApiService,
     private val clientRepository: LedStripClientRepository,
     private val stripRepository: LedStripRepository,
-    private val streamJobManager: StreamJobManager
+    private val streamJobManager: StreamJobManager,
+    private val clientStatusService: ClientStatusService,
+    private val sseEventEmitter: SseEventEmitter,
 ) : StringSpec({
 
     lateinit var mockStreamJobManager: StreamJobManager
+    lateinit var mockClientStatusService: ClientStatusService
+
+    // SseEventEmitter is a final concrete bean (not proxyable), so it can't be a @MockBean. Instead we
+    // subscribe to its event stream and collect everything emitted. Emission is synchronous, so the list is
+    // fully populated by the time the service call returns. The subscription lives for the whole spec: the
+    // multicast sink auto-cancels once it has no subscribers, so disposing per-test would kill it for the
+    // following tests. We clear the list before each test instead.
+    val emittedEvents = CopyOnWriteArrayList<SseEvent>()
+    var eventSubscription: Disposable? = null
+
+    beforeSpec {
+        eventSubscription = sseEventEmitter.events.subscribe { emittedEvents.add(it) }
+    }
+
+    afterSpec {
+        eventSubscription?.dispose()
+    }
 
     beforeTest {
         mockStreamJobManager = getMock(streamJobManager)
+        mockClientStatusService = getMock(clientStatusService)
+
+        // Sensible default so response mapping has a deterministic status; individual tests override as needed.
+        every { mockClientStatusService.getStatusForClient(any()) } returns
+                Optional.of(ClientStatusInfo.inactive(ClientStatus.Idle))
+
+        emittedEvents.clear()
     }
 
     afterTest {
         stripRepository.deleteAll()
         clientRepository.deleteAll()
+    }
+
+    "getAllClients returns empty response when no clients exist" {
+        val response = ledClientApiService.getAllClients()
+        response.clients.isEmpty() shouldBe true
+    }
+
+    "getAllClients returns every persisted client mapped to a response" {
+        createLedStripClientEntity(clientRepository, "Client A", "192.168.1.10", 8000, 8001)
+        createLedStripClientEntity(clientRepository, "Client B", "192.168.1.11", 8002, 8003)
+        createLedStripClientEntity(clientRepository, "Client C", "192.168.1.12", 8004, 8005)
+
+        val response = ledClientApiService.getAllClients()
+
+        response.clients.size shouldBe 3
+        response.clients.map { it.name }.toSet() shouldBe setOf("Client A", "Client B", "Client C")
+        response.clients.map { it.address }.toSet() shouldBe setOf("192.168.1.10", "192.168.1.11", "192.168.1.12")
+    }
+
+    "getClientWithUuid returns the matching client mapped with all fields" {
+        val client = createLedStripClientEntity(
+            clientRepository, "Test Client", "192.168.1.100", 8000, 8001, powerLimit = 250
+        )
+        every { mockClientStatusService.getStatusForClient(any()) } returns
+                Optional.of(ClientStatusInfo(ClientStatus.Active, 4))
+
+        val response = ledClientApiService.getClientWithUuid(client.uuid)
+
+        response.uuid shouldBe client.uuid
+        response.name shouldBe client.name
+        response.address shouldBe client.address
+        response.clientType shouldBe client.clientType.toString()
+        response.colorOrder shouldBe client.colorOrder
+        response.apiPort shouldBe client.apiPort
+        response.wsPort shouldBe client.wsPort
+        response.lastSeenAt shouldBe client.lastSeenAt
+        response.powerLimit shouldBe client.powerLimit
+        response.firmwareVersion shouldBe client.firmwareVersion
+        response.fps shouldBe client.fps
+        response.fadeTimeoutMillis shouldBe client.fadeTimeoutMillis
+        response.status shouldBe ClientStatus.Active
+        response.activeEffects shouldBe 4
+    }
+
+    "getClientWithUuid throws ResourceNotFoundException when the client does not exist" {
+        shouldThrow<ResourceNotFoundException> {
+            ledClientApiService.getClientWithUuid(UUID.randomUUID().toString())
+        }
+    }
+
+    "createClient persists the client, starts streaming, emits a created event and returns the uuid" {
+        val request = CreateClientRequest(
+            name = "New Client",
+            address = "192.168.1.50",
+            clientType = ClientType.Pi,
+            colorOrder = ColorOrder.GRB,
+            apiPort = 9000,
+            wsPort = 9001,
+            powerLimit = 500,
+            fps = 60,
+            fadeTimeoutMillis = 1000,
+        )
+
+        val uuid = ledClientApiService.createClient(request)
+
+        val saved = clientRepository.findByUuid(uuid)
+        saved.isPresent shouldBe true
+        val entity = saved.get()
+        entity.name shouldBe request.name
+        entity.address shouldBe request.address
+        entity.clientType shouldBe request.clientType
+        entity.colorOrder shouldBe ColorOrder.GRB
+        entity.apiPort shouldBe request.apiPort
+        entity.wsPort shouldBe request.wsPort
+        entity.powerLimit shouldBe request.powerLimit
+        entity.fps shouldBe request.fps
+        entity.fadeTimeoutMillis shouldBe request.fadeTimeoutMillis
+        entity.firmwareVersion shouldBe LedStripClientEntity.DEFAULT_FIRMWARE_VERSION
+
+        verify(exactly = 1) { mockStreamJobManager.startStreamingJob(any()) }
+
+        emittedEvents.size shouldBe 1
+        val event = emittedEvents.first()
+        event.shouldBeInstanceOf<LedClientEvent.LedClientCreated>()
+        event.uuid shouldBe uuid
+        val data = event.data
+        data.shouldBeInstanceOf<GetClientResponse>()
+        data.name shouldBe request.name
+        data.address shouldBe request.address
+    }
+
+    "createClient defaults colorOrder to RGB when not provided" {
+        val request = CreateClientRequest(
+            name = "Pi Client",
+            address = "192.168.1.51",
+            clientType = ClientType.Pi,
+            colorOrder = null,
+            apiPort = 9000,
+            wsPort = 9001,
+            powerLimit = 100,
+        )
+
+        val uuid = ledClientApiService.createClient(request)
+
+        clientRepository.findByUuid(uuid).get().colorOrder shouldBe ColorOrder.RGB
+    }
+
+    "createClient defaults powerLimit, fps and fadeTimeout when not provided" {
+        val request = CreateClientRequest(
+            name = "Defaults Client",
+            address = "192.168.1.52",
+            clientType = ClientType.Pi,
+            colorOrder = ColorOrder.RGB,
+            apiPort = 9000,
+            wsPort = 9001,
+            powerLimit = null,
+            fps = null,
+            fadeTimeoutMillis = null,
+        )
+
+        val uuid = ledClientApiService.createClient(request)
+
+        val entity = clientRepository.findByUuid(uuid).get()
+        entity.powerLimit shouldBe 0
+        entity.fps shouldBe LedStripClientEntity.DEFAULT_FPS
+        entity.fadeTimeoutMillis shouldBe LedStripClientEntity.DEFAULT_FADE_TIMEOUT_MILLIS
+    }
+
+    "createClient throws ClientRequestException when a client with the same address exists" {
+        createLedStripClientEntity(clientRepository, "Existing", "192.168.1.99", 8000, 8001)
+
+        val request = CreateClientRequest(
+            name = "Duplicate",
+            address = "192.168.1.99",
+            clientType = ClientType.Pi,
+            colorOrder = ColorOrder.RGB,
+            apiPort = 9000,
+            wsPort = 9001,
+            powerLimit = null,
+        )
+
+        shouldThrow<ClientRequestException> {
+            ledClientApiService.createClient(request)
+        }
+
+        // No side effects should have happened on the conflict path.
+        verify(exactly = 0) { mockStreamJobManager.startStreamingJob(any()) }
+        emittedEvents.isEmpty() shouldBe true
     }
 
     "Update client with powerLimit change triggers stream restart" {
@@ -168,6 +362,52 @@ class LedClientApiServiceTest(
         verify(atLeast = 1) { mockStreamJobManager.startStreamingJob(any()) }
     }
 
+    "Update client with fps change triggers stream restart" {
+        val client = createLedStripClientEntity(
+            clientRepository, "Test Client", "192.168.1.100", 8000, 8001, fps = 30
+        )
+
+        val updateRequest = UpdateClientRequest(
+            name = null,
+            address = null,
+            colorOrder = null,
+            apiPort = null,
+            wsPort = null,
+            powerLimit = null,
+            fps = 90  // Changed
+        )
+
+        ledClientApiService.updateClient(client.uuid, updateRequest)
+
+        verify(atLeast = 1) { mockStreamJobManager.stopWebsocketJob(any()) }
+        verify(atLeast = 1) { mockStreamJobManager.startStreamingJob(any()) }
+
+        clientRepository.findByUuid(client.uuid).get().fps shouldBe 90
+    }
+
+    "Update client with fade timeout change triggers stream restart" {
+        val client = createLedStripClientEntity(
+            clientRepository, "Test Client", "192.168.1.100", 8000, 8001, fadeTimeoutMillis = 5000
+        )
+
+        val updateRequest = UpdateClientRequest(
+            name = null,
+            address = null,
+            colorOrder = null,
+            apiPort = null,
+            wsPort = null,
+            powerLimit = null,
+            fadeTimeoutMillis = 20000  // Changed
+        )
+
+        ledClientApiService.updateClient(client.uuid, updateRequest)
+
+        verify(atLeast = 1) { mockStreamJobManager.stopWebsocketJob(any()) }
+        verify(atLeast = 1) { mockStreamJobManager.startStreamingJob(any()) }
+
+        clientRepository.findByUuid(client.uuid).get().fadeTimeoutMillis shouldBe 20000
+    }
+
     "Update client with only name change does not trigger stream restart" {
         val client = createLedStripClientEntity(
             clientRepository,
@@ -194,7 +434,146 @@ class LedClientApiServiceTest(
         val updatedClient = clientRepository.findByUuid(client.uuid).get()
         updatedClient.name shouldBe updateRequest.name
     }
+
+    "updateClient leaves fields unchanged when their request values are null" {
+        val client = createLedStripClientEntity(
+            clientRepository, "Original", "192.168.1.100", 8000, 8001, powerLimit = 75, fps = 40, fadeTimeoutMillis = 3000
+        )
+        val originalColorOrder = client.colorOrder
+
+        val updateRequest = UpdateClientRequest(
+            name = "Renamed",
+            address = null,
+            colorOrder = null,
+            apiPort = null,
+            wsPort = null,
+            powerLimit = null,
+        )
+
+        ledClientApiService.updateClient(client.uuid, updateRequest)
+
+        val updated = clientRepository.findByUuid(client.uuid).get()
+        updated.name shouldBe "Renamed"
+        updated.address shouldBe client.address
+        updated.colorOrder shouldBe originalColorOrder
+        updated.apiPort shouldBe client.apiPort
+        updated.wsPort shouldBe client.wsPort
+        updated.powerLimit shouldBe 75
+        updated.fps shouldBe 40
+        updated.fadeTimeoutMillis shouldBe 3000
+    }
+
+    "updateClient emits an update event whose delta only contains changed fields" {
+        val client = createLedStripClientEntity(
+            clientRepository, "Original", "192.168.1.100", 8000, 8001, powerLimit = 75
+        )
+
+        val updateRequest = UpdateClientRequest(
+            name = "Renamed",
+            address = null,
+            colorOrder = null,
+            apiPort = null,
+            wsPort = null,
+            powerLimit = null,
+        )
+
+        ledClientApiService.updateClient(client.uuid, updateRequest)
+
+        emittedEvents.size shouldBe 1
+        val event = emittedEvents.first()
+        event.shouldBeInstanceOf<LedClientEvent.LedClientUpdated>()
+        event.uuid shouldBe client.uuid
+        val delta = event.data
+        delta.shouldBeInstanceOf<ClientDelta>()
+        delta.name shouldBe "Renamed"
+        delta.address shouldBe null
+        delta.colorOrder shouldBe null
+        delta.apiPort shouldBe null
+        delta.wsPort shouldBe null
+        delta.powerLimit shouldBe null
+        delta.fps shouldBe null
+        delta.fadeTimeoutMillis shouldBe null
+    }
+
+    "updateClient throws ResourceNotFoundException when the client does not exist" {
+        val updateRequest = UpdateClientRequest(
+            name = "Whatever",
+            address = null,
+            colorOrder = null,
+            apiPort = null,
+            wsPort = null,
+            powerLimit = null,
+        )
+
+        shouldThrow<ResourceNotFoundException> {
+            ledClientApiService.updateClient(UUID.randomUUID().toString(), updateRequest)
+        }
+
+        verify(exactly = 0) { mockStreamJobManager.startStreamingJob(any()) }
+        emittedEvents.isEmpty() shouldBe true
+    }
+
+    "deleteClient removes the client, stops its job and emits a deleted event when it has no strips" {
+        val client = createLedStripClientEntity(clientRepository, "To Delete", "192.168.1.70", 8000, 8001)
+
+        ledClientApiService.deleteClient(client.uuid)
+
+        clientRepository.findByUuid(client.uuid).isPresent shouldBe false
+        verify(exactly = 1) { mockStreamJobManager.stopWebsocketJob(any()) }
+
+        emittedEvents.size shouldBe 1
+        val event = emittedEvents.first()
+        event.shouldBeInstanceOf<LedClientEvent.LedClientDeleted>()
+        event.uuid shouldBe client.uuid
+        event.data shouldBe null
+    }
+
+    "deleteClient throws ClientRequestException and keeps the client when it still has strips" {
+        val client = createLedStripClientEntity(clientRepository, "Has Strips", "192.168.1.71", 8000, 8001)
+        saveLedStrip(stripRepository, client, "Strip", 60, "D10", 100)
+
+        shouldThrow<ClientRequestException> {
+            ledClientApiService.deleteClient(client.uuid)
+        }
+
+        clientRepository.findByUuid(client.uuid).isPresent shouldBe true
+        verify(exactly = 0) { mockStreamJobManager.stopWebsocketJob(any()) }
+        emittedEvents.isEmpty() shouldBe true
+    }
+
+    "deleteClient throws ResourceNotFoundException when the client does not exist" {
+        shouldThrow<ResourceNotFoundException> {
+            ledClientApiService.deleteClient(UUID.randomUUID().toString())
+        }
+
+        verify(exactly = 0) { mockStreamJobManager.stopWebsocketJob(any()) }
+        emittedEvents.isEmpty() shouldBe true
+    }
+
+    "mapClientEntityToResponse reflects the status and active effect count from the status service" {
+        val client = createLedStripClientEntity(clientRepository, "Mapped", "192.168.1.80", 8000, 8001)
+        every { mockClientStatusService.getStatusForClient(any()) } returns
+                Optional.of(ClientStatusInfo(ClientStatus.Active, 7))
+
+        val response = ledClientApiService.mapClientEntityToResponse(client)
+
+        response.status shouldBe ClientStatus.Active
+        response.activeEffects shouldBe 7
+    }
+
+    "mapClientEntityToResponse falls back to error status when the status service has none" {
+        val client = createLedStripClientEntity(clientRepository, "No Status", "192.168.1.81", 8000, 8001)
+        every { mockClientStatusService.getStatusForClient(any()) } returns Optional.empty()
+
+        val response = ledClientApiService.mapClientEntityToResponse(client)
+
+        response.status shouldBe ClientStatus.Error
+        response.activeEffects shouldBe 0
+    }
 }) {
     @MockBean(StreamJobManager::class)
     fun streamJobManager(): StreamJobManager = mockk(relaxed = true)
+
+    @MockBean(ClientStatusService::class)
+    fun clientStatusService(): ClientStatusService = mockk(relaxed = true)
 }


### PR DESCRIPTION
Database query optimizations, added throwing an exception for create client requests if a client with the same address already exists